### PR TITLE
Lein datomic config

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,9 @@
 (defproject datomic-rest-api "0.0.3-SNAPSHOT"
   :description "REST API for retrieving data from datomic on a per widget basis"
-
   :min-lein-version "2.0.0"
-
+  :repositories {"my.datomic.com" {:url "https://my.datomic.com/repo"
+                                   :creds :gpg}}
   :dependencies [[org.clojure/clojure "1.8.0"]
- ;;                [com.datomic/datomic-free "0.9.5186" :exclusions [joda-time]]
                  [com.datomic/datomic-pro "0.9.5359" :exclusions [joda-time]] ;; added
                  [com.amazonaws/aws-java-sdk-dynamodb "1.9.39" :exclusions [joda-time]] ;; added
                  [datomic-schema "1.3.0"]

--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,6 @@
                  [cheshire "5.6.1"]
                  [secretary "1.2.3"]
                  [environ "1.0.3"]]
-
   :profiles {:dev {:dependencies [[midje "1.6.3"]]
                  :plugins [[lein-midje "3.1.3"]]}}
 
@@ -37,5 +36,5 @@
   :jvm-opts ["-Xmx6G"
              "-XX:+UseG1GC" "-XX:MaxGCPauseMillis=50"  ;; same GC options as the transactor,
                                                        ;; should minimize long pauses.
-             "-Ddatomic.objectCacheMax=2500000000" 
+             "-Ddatomic.objectCacheMax=2500000000"
              "-Ddatomic.txTimeoutMsec=1000000"])


### PR DESCRIPTION
Lets lein find and download datomic-pro.

Requires user has configured gpg credentials storage  (e.g: `~/.lein/credentials.clj.gpg`)

Tested by removing the ~/.m2 directory and running `lein repl`
