### PR TITLE
Feature/prep for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@
 lein deploy clojars
 ```
 
-###Create war file
+###Create jar file
 ```
 lein with-profile +datomic-pro,+ddb uberjar
 ```
 
 ####Test deploying the jar
 
-To see inside the war
+To see inside the jar
 ```
 jar tvf ./target/<jar-name>.jar
 ```

--- a/README.md
+++ b/README.md
@@ -3,10 +3,32 @@
 - Provide interface to datomic database to WormBase website. 
 
 ##Setting environment variables
-    export TRACE_PORT=8130
     export TRACE_DB="datomic:ddb://us-east-1/wormbase/WS254"
 
-## starting server
+##Starting server in development
 
-    lein repl
-    >  (use 'web.core)
+    lein with-profile +datomic-pro,+ddb ring server-headless 8130
+
+##Deploying to production
+
+###Deploy to Clojars (to be used by other clojar projects)
+```
+lein deploy clojars
+```
+
+###Create war file
+```
+lein with-profile +datomic-pro,+ddb uberjar
+```
+
+####Test deploying the jar
+
+To see inside the war
+```
+jar tvf ./target/<jar-name>.jar
+```
+
+To do a test deploy
+```
+sudo java -server -jar <jar-name>.jar
+```

--- a/project.clj
+++ b/project.clj
@@ -3,10 +3,8 @@
   :min-lein-version "2.0.0"
   :dependencies 
   [[org.clojure/clojure "1.8.0"]
-   [com.datomic/datomic-pro "0.9.5385"
-    :exclusions [joda-time]] 
-   [com.amazonaws/aws-java-sdk-dynamodb "1.11.6"
-    :exclusions [joda-time]] 
+   [com.datomic/datomic-free "0.9.5385"
+    :exclusions [joda-time]]
    [datomic-schema "1.3.0"]
    [wormbase/pseudoace "0.4.10"]
    [mount "0.1.10"]
@@ -31,6 +29,9 @@
   :plugins [[lein-cljsbuild "1.1.3"]
             [lein-pprint "1.1.1"]
             [lein-ring "0.9.7"]]
+  :datomic-pro {:dependencies [[com.datomic/datomic-pro "0.9.5385"
+                                           :exclusions [joda-time]]]
+                           :exclusions [com.datomic/datomic-free]}
   :env {:trace-db "datomic:ddb://us-east-1/wormbase/WS254"
         :trace-port "8120"}
   :main datomic-rest-api.get-handler
@@ -52,4 +53,9 @@
                              [lein-ancient "0.6.8"]
                              [lein-bikeshed "0.3.0"]
                              [lein-kibit "0.1.2"]
-                             [lein-ns-dep-graph "0.1.0-SNAPSHOT"]]}})
+                             [lein-ns-dep-graph "0.1.0-SNAPSHOT"]]}
+              :datomic-pro {:dependencies [[com.datomic/datomic-pro "0.9.5385"
+                                            :exclusions [joda-time]]]
+                           :exclusions [com.datomic/datomic-free]}
+              :ddb {:dependencies [[com.amazonaws/aws-java-sdk-dynamodb "1.11.6"
+                                    :exclusions [joda-time]]]}})

--- a/project.clj
+++ b/project.clj
@@ -29,9 +29,6 @@
   :plugins [[lein-cljsbuild "1.1.3"]
             [lein-pprint "1.1.1"]
             [lein-ring "0.9.7"]]
-  :datomic-pro {:dependencies [[com.datomic/datomic-pro "0.9.5385"
-                                           :exclusions [joda-time]]]
-                           :exclusions [com.datomic/datomic-free]}
   :env {:trace-db "datomic:ddb://us-east-1/wormbase/WS254"
         :trace-port "8120"}
   :main datomic-rest-api.get-handler

--- a/src/datomic_rest_api/get_handler.clj
+++ b/src/datomic_rest_api/get_handler.clj
@@ -19,39 +19,49 @@
 
 (defn app-routes [db]
    (routes
-     (GET "/" [] "hello")
-     (GET "/rest/widget/gene/:id/overview" {params :params}
-         (gene/overview db (:id params) (str "rest/widget/gene/" (:id params) "/overview")))
-     (GET "/rest/widget/gene/:id/history" {params :params}
-         (gene/history db (:id params) (str "rest/widget/gene/" (:id params) "/history"))) ;; perfect match
-     (GET "/rest/widget/gene/:id/phenotype" {params :params}
-         (gene/phenotypes db (:id params) (str "rest/widget/gene/" (:id params) "/phenotype"))) ;; broken because of variation/phenotype
-     (GET "/rest/widget/gene/:id/interactions" {params :params}
-         (get-interactions "gene" db (:id params) (str "rest/widget/gene/" (:id params) "/interactions"))) ;; needed work on nodes all - not quite lining up
-     (GET "/rest/field/gene/:id/interaction_details" {params :params}
-         (get-interaction-details "gene" db (:id params) (str "rest/field/gene/" (:id params) "/interaction_details"))) ;; wormbase is missing data section: why?
-     (GET "/rest/widget/gene/:id/mapping_data" {params :params}
-         (gene/mapping-data db (:id params) (str "rest/widget/gene/" (:id params) "/mapping_data")))
-     (GET "/rest/widget/gene/:id/human_diseases" {params :params}
-         (gene/human-diseases db (:id params) (str "rest/widget/gene/" (:id params) "/human_disease")))
-     (GET "/rest/widget/gene/:id/references" {params :params}
-         (get-references "gene" db (:id params) (str "rest/widget/gene/" (:id params) "/references")))
-     (GET "/rest/widget/gene/:id/reagents" {params :params}
-         (gene/reagents db (:id params) (str "rest/widget/gene/" (:id params) "/reagents"))) ;; looks correct; needs sort to confirm
-     (GET "/rest/widget/gene/:id/gene_ontology" {params :params}
-         (gene/gene-ontology db (:id params) (str "rest/widget/gene/" (:id params) "/gene_ontology"))) ;; substancially same structure. not producing the same results 
-     (GET "/rest/widget/gene/:id/expression" {params :params}
-         (gene/expression db (:id params) (str "rest/widget/gene/" (:id params) "/expression"))) ;; This one is predominantly done but needs a little checking and sequence data
-     (GET "/rest/widget/gene/:id/homology" {params :params}
-         (gene/homology db (:id params) (str "rest/widget/gene/" (:id params) "/homology"))) ;; need to wait for homology data to be added to datomic database
-     (GET "/rest/widget/gene/:id/sequences" {params :params}
-         (gene/sequences db (:id params) (str "rest/widget/gene/" (:id params) "/sequences")))
-     (GET "/rest/widget/gene/:id/feature" {params :params}
-         (gene/features db (:id params) (str "rest/widget/gene/" (:id params) "/feature"))) ;; has a few values missing for gbrowse - not sure if needed or possible to get out of datomic
-     (GET "/rest/widget/gene/:id/genetics" {params :params}
-         (gene/genetics db (:id params) (str "rest/widget/gene/" (:id params) "/genetics"))) ;; looks good need to find rearrangement that exists. Also need to test if works, when does not exist, with Perl template
+     (GET "/" [] "<html>
+                    <h5>Widgets</h5>
+                    <ul>
+                       <li><a href=\"./rest/widget/\">/rest/widget/</a></li>
+                    <ul>
+                  </html>")
+     (GET "/rest/widget/" [] "<html>
+                    <ul>
+                      <li>/rest/widget/gene/:id/external_links</li>
+                    </ul>
+                  </html>")
+;;     (GET "/rest/widget/gene/:id/overview" {params :params}
+;;         (gene/overview db (:id params) (str "rest/widget/gene/" (:id params) "/overview")))
+;;     (GET "/rest/widget/gene/:id/history" {params :params}
+;;         (gene/history db (:id params) (str "rest/widget/gene/" (:id params) "/history")))
+;;     (GET "/rest/widget/gene/:id/phenotype" {params :params}
+;;         (gene/phenotypes db (:id params) (str "rest/widget/gene/" (:id params) "/phenotype"))) ;; broken because of variation/phenotype
+;;     (GET "/rest/widget/gene/:id/interactions" {params :params}
+;;         (get-interactions "gene" db (:id params) (str "rest/widget/gene/" (:id params) "/interactions"))) ;; needed work on nodes all - not quite lining up
+;;     (GET "/rest/field/gene/:id/interaction_details" {params :params}
+;;         (get-interaction-details "gene" db (:id params) (str "rest/field/gene/" (:id params) "/interaction_details"))) ;; wormbase is missing data section: why?
+;;     (GET "/rest/widget/gene/:id/mapping_data" {params :params}
+;;         (gene/mapping-data db (:id params) (str "rest/widget/gene/" (:id params) "/mapping_data")))
+;;     (GET "/rest/widget/gene/:id/human_diseases" {params :params}
+;;         (gene/human-diseases db (:id params) (str "rest/widget/gene/" (:id params) "/human_disease")))
+;;     (GET "/rest/widget/gene/:id/references" {params :params}
+;;         (get-references "gene" db (:id params) (str "rest/widget/gene/" (:id params) "/references")))
+;;     (GET "/rest/widget/gene/:id/reagents" {params :params}
+;;         (gene/reagents db (:id params) (str "rest/widget/gene/" (:id params) "/reagents"))) ;; looks correct; needs sort to confirm
+;;     (GET "/rest/widget/gene/:id/gene_ontology" {params :params}
+;;         (gene/gene-ontology db (:id params) (str "rest/widget/gene/" (:id params) "/gene_ontology"))) ;; substancially same structure. not producing the same results 
+;;     (GET "/rest/widget/gene/:id/expression" {params :params}
+;;         (gene/expression db (:id params) (str "rest/widget/gene/" (:id params) "/expression"))) ;; This one is predominantly done but needs a little checking and sequence data
+;;     (GET "/rest/widget/gene/:id/homology" {params :params}
+;;         (gene/homology db (:id params) (str "rest/widget/gene/" (:id params) "/homology"))) ;; need to wait for homology data to be added to datomic database
+;;     (GET "/rest/widget/gene/:id/sequences" {params :params}
+;;         (gene/sequences db (:id params) (str "rest/widget/gene/" (:id params) "/sequences")))
+;;     (GET "/rest/widget/gene/:id/feature" {params :params}
+;;         (gene/features db (:id params) (str "rest/widget/gene/" (:id params) "/feature"))) ;; has a few values missing for gbrowse - not sure if needed or possible to get out of datomic
+;;     (GET "/rest/widget/gene/:id/genetics" {params :params}
+;;         (gene/genetics db (:id params) (str "rest/widget/gene/" (:id params) "/genetics"))) ;; looks good need to find rearrangement that exists. Also need to test if works, when does not exist, with Perl template
      (GET "/rest/widget/gene/:id/external_links" {params :params}
-         (gene/external-links db (:id params) (str "rest/widget/gene/" (:id params) "/external_links"))))) ;; works
+         (gene/external-links db (:id params) (str "rest/widget/gene/" (:id params) "/external_links")))))
 
 (defn init []
   (print "Making Connection\n")


### PR DESCRIPTION
In this branch I have fixed up how the datomic-pro dependency is configured in the project.clj. This change now makes it so that the user has to specify to use the profiles datomic-pro and ddb if they are wanting to use the tool with the DynamoDB version of database. 

I have also commented out all the URLs but the external_links URL. This URL is by far the least complex and should serve as a great starting point for testing the API in production. 
## Releases
### 0.0.1

This release will contain several URL's that have including but not limited to external_links.
### 0.0.2

This release will add the history and the phenotype URLs
### 0.0.3

This release will contain several URL's that are more complex to check but are currently likely correct.
