### PR TITLE
Feature/enable runtime configuration via envvars

### DIFF
--- a/src/datomic_rest_api/utils/db.clj
+++ b/src/datomic_rest_api/utils/db.clj
@@ -3,13 +3,13 @@
             [environ.core :refer (env)]
             [datomic.api :as d]))
 
-(def uri (env :trace-db))
-
 (defn- new-datomic-connection [uri]
     (d/connect uri))
 
 (defn- datomic-disconnect [conn]
    (d/release conn))
 
-(defstate datomic-conn :start (new-datomic-connection uri)
-                       :stop (datomic-disconnect datomic-conn))
+(defstate datomic-conn
+  :start (fn []
+           (new-datomic-connection (env :trace-db))
+           :stop (datomic-disconnect datomic-conn))

--- a/src/datomic_rest_api/utils/db.clj
+++ b/src/datomic_rest_api/utils/db.clj
@@ -4,10 +4,10 @@
             [datomic.api :as d]))
 
 (defn- new-datomic-connection [uri]
-    (d/connect uri))
+  (d/connect uri))
 
 (defn- datomic-disconnect [conn]
-   (d/release conn))
+  (d/release conn))
 
 (defstate datomic-conn
   :start (fn []

--- a/src/datomic_rest_api/utils/db.clj
+++ b/src/datomic_rest_api/utils/db.clj
@@ -12,4 +12,4 @@
 (defstate datomic-conn
   :start (fn []
            (new-datomic-connection (env :trace-db))
-           :stop (datomic-disconnect datomic-conn))
+           :stop (datomic-disconnect datomic-conn)))


### PR DESCRIPTION
This makes it possible to configure a different datomic URL at runtime as opposed to at compilation time.
i.e Without this change, you'd need to set the environment variable `TRACE_DB` before running
`lein ring uberjar`.

(Preparation for elasticbeanstalk deployment)
