### PR TITLE
Use the standard environment variable for AWS EB profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ docker/${DEPLOY_JAR}: $(call print-help,docker/app.jar,\
 
 .PHONY: docker-ecr-login
 docker-ecr-login: $(call print-help,docker-ecr-login,"Login to ECR")
-	@eval $(shell aws --profile ${AWS_PROFILE} ecr get-login)
+	@eval $(shell aws ecr get-login)
 
 .PHONY: docker-tag
 docker-tag: $(call print-help,docker-tag,\
@@ -43,9 +43,8 @@ eb-create: $(call print-help,eb-create,\
 	    "Create an ElasticBeanStalk environment using \
 	     the Docker platofrm.")
 	@eb create datomic-to-catalyst \
-		--profile=${AWS_PROFILE} \
 		--region=us-east-1 \
-		--tags="CreatedBy=${AWS_PROFILE},Role=Rest\ API" \
+		--tags="CreatedBy=${AWS_EB_PROFILE},Role=Rest\ API" \
 		--instance_type="c4.xlarge" \
 		--vpc.id="vpc-8e0087e9" \
 		--vpc.ec2subnets="subnet-a33a2bd5" \

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ java -server -jar <jar-name>.jar
 
 ## Docker
 
+Ensure you set the `AWS_EB_PROFILE` environment variable to your AWS
+username before running Makefile commands.
+
+It may be useful to put this in your shell profile, e.g for bash:
+
+```bash
+# when your aws username is the same as your local unix username:
+export AWS_EB_PROFILE="${USER}"
+```
+
 Build an uberjar (with ring server support) on the local machine
 to avoid having to download dependencies in the container:
 


### PR DESCRIPTION
Fixes #20

It should be noted, that whilst this PR explicitly uses `$AWS_EB_PROFILE` for use with the `eb` CLI, 
the `aws` CLI uses `$AWS_DEFAULT_PROFILE`.

Since we use  __both__ CLIs (`aws` and `eb` - in manual usage _and_ in the `Makefile` for this project),
it' is now required for users to configure their shell accordingly.

For example, I have a file `~/.aws/env` which I've [configured](https://github.com/mgrbyte/dot-files/blob/master/zsh/.zshenv#L84-L89) my shell profile to source at login, that looks like the following (secrets elided):

``` bash
export AWS_DEFAULT_PROFILE="mrussell"
export AWS_DEFAULT_REGION="us-east-1" # always the default for the WormBase project
export AWS_ACCESS_KEY_ID="..."
export AWS_SECRET_ACCESS_KEY="..."
export AWS_EB_PROFILE="${AWS_DEFAULT_PROFILE}"
```
