### PR TITLE
Feature/add mem stats cw

### DIFF
--- a/.ebextensions/cloudwatch.config
+++ b/.ebextensions/cloudwatch.config
@@ -1,0 +1,26 @@
+packages:
+  yum:
+    perl-DateTime: []
+    perl-Sys-Syslog: []
+    perl-LWP-Protocol-https: []
+    perl-Switch: []
+    perl-URI: []
+    perl-Bundle-LWP: []
+
+sources: 
+  /opt/cloudwatch: http://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.1.zip
+  
+container_commands:
+  01-setupcron:
+    command: |
+      echo '*/5 * * * * root perl /opt/cloudwatch/aws-scripts-mon/mon-put-instance-data.pl `{"Fn::GetOptionSetting" : { "OptionName" : "CloudWatchMetrics", "DefaultValue" : "--mem-util --disk-space-util --disk-path=/" }}` >> /var/log/cwpump.log 2>&1' > /etc/cron.d/cwpump
+  02-changeperm:
+    command: chmod 644 /etc/cron.d/cwpump
+  03-changeperm:
+    command: chmod u+x /opt/cloudwatch/aws-scripts-mon/mon-put-instance-data.pl
+
+option_settings:
+  "aws:autoscaling:launchconfiguration" :
+    IamInstanceProfile : "datomic-to-catalyst"
+  "aws:elasticbeanstalk:customoption" :
+    CloudWatchMetrics : "--mem-util --mem-used --mem-avail --disk-space-util --disk-space-used --disk-space-avail --disk-path=/ --auto-scaling"

--- a/.ebextensions/cloudwatch.config
+++ b/.ebextensions/cloudwatch.config
@@ -21,6 +21,6 @@ container_commands:
 
 option_settings:
   "aws:autoscaling:launchconfiguration" :
-    IamInstanceProfile : "datomic-to-catalyst"
+    IamInstanceProfile : "aws-elasticbeanstalk-ec2-role"
   "aws:elasticbeanstalk:customoption" :
     CloudWatchMetrics : "--mem-util --mem-used --mem-avail --disk-space-util --disk-space-used --disk-space-avail --disk-path=/ --auto-scaling"


### PR DESCRIPTION
This Pull request includes changes from the following URL: http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/customize-containers-cw.html

This allows us to monitor the machines memory utilization in the CloudWatch console. 

There were three steps involved:

1) Adding an in-line policy to the instances role called de-cloudwatch
2) Adding the .ebextensions/cloudwatch.config file (from the link with our role specified)
3) Running "eb deploy"

Unfortunately there is no obvious easy way to add CPU monitoring. There doesn't seem to be a" --cpu" flag available: http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/mon-scripts.html#mon-scripts-using

It would be very useful to have a future task be to add CPU monitoring.
