### PR TITLE
dev related helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ pm_to_blib
 target/
 .lein-env
 .lein-repl-history
+.lein-plugins/
+.lein-failures
 .nrepl-port
 
 # Elastic Beanstalk Files
@@ -30,3 +32,8 @@ target/
 
 #docker
 docker/app.jar
+
+
+# for Emacs
+*~
+\#*\#

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,0 +1,36 @@
+(ns user
+  (:require [clojure.string :as str]
+            [clojure.pprint :refer (pprint)]
+            [clojure.repl :refer :all]
+            [clojure.test :as test]
+            [clojure.tools.namespace.repl :refer (refresh refresh-all)]
+            [datomic.api :as d]
+            [mount.core :as mount]
+            [datomic-rest-api.utils.db :refer (datomic-conn)]))
+
+
+
+(defn resolve-xref-info
+  "Resolve object references to an attribute `ident` given a `db` handle.
+
+  Returned map may contain the following keys:
+     `:ref-schema` - symbol of the referenced schema
+     `:component-schema` - symbol of the component schema if `ident`
+                           is a component attribute.
+  "
+  [db ident]
+  (if-let [attr (d/entity db ident)]
+    (if (:db/isComponent attr)
+      {:component-schema (-> (:pace/use-ns attr)
+                             (first)
+                             (symbol))
+       :ref-schema (symbol (str (namespace ident)
+                                "."
+                                (name ident)))}
+      (if-let [ref (:pace/obj-ref attr)]
+        {:ref-schema (-> ref
+                         (namespace)
+                         (symbol))}
+        ))
+    (throw (Exception. (str ident
+                            " is not a valid schema attribute")))))

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/WormBase/datomic-to-catalyst"
   :min-lein-version "2.0.0"
   :sign-releases false
-  :dependencies 
+  :dependencies
   [[org.clojure/clojure "1.8.0"]
    [datomic-schema "1.3.0"]
    [wormbase/pseudoace "0.4.10"]
@@ -11,7 +11,7 @@
    [hiccup "1.0.5"]
    [ring "1.5.0"]
    [ring/ring-anti-forgery "1.0.1"]
-   [ring/ring-jetty-adapter "1.5.0"] 
+   [ring/ring-jetty-adapter "1.5.0"]
    [fogus/ring-edn "0.2.0"]
    [compojure "1.4.0"]
    [clj-http "3.1.0"]
@@ -43,6 +43,7 @@
   :profiles {:dev {:dependencies [;;[midje "1.8.3"]
                               ;;    [datomic-schema-grapher "0.0.1"]
                                   [ring/ring-devel "1.5.0"]]
+                   :source-paths ["dev"]
                    :env {:trace-db "datomic:ddb://us-east-1/WS255/wormbase"}
                    :plugins [;;[lein-midje "3.2"]
                              [jonase/eastwood "0.2.3"]


### PR DESCRIPTION
Hi @mgrbyte @a8wright this PR is for setting up user.clj to contain dev/repl only helper function as described http://thinkrelevance.com/blog/2013/06/04/clojure-workflow-reloaded

- include helper functions for repl in dev/user.clj
   - Functions defined in dev/user.clj can be loaded into the repl by use or require its namespace 'user.
   - resolve-xref-info that @mgrbyte wrote is included in user.clj

- update .gitignore for lein and Emacs related files to ignore