### PR TITLE
remove trailing whitespaces on .clj files only

### DIFF
--- a/src/datomic_rest_api/get_handler.clj
+++ b/src/datomic_rest_api/get_handler.clj
@@ -52,7 +52,7 @@
 ;;     (GET "/rest/widget/gene/:id/reagents" {params :params}
 ;;         (gene/reagents db (:id params) (str "rest/widget/gene/" (:id params) "/reagents"))) ;; looks correct; needs sort to confirm
 ;;     (GET "/rest/widget/gene/:id/gene_ontology" {params :params}
-;;         (gene/gene-ontology db (:id params) (str "rest/widget/gene/" (:id params) "/gene_ontology"))) ;; substancially same structure. not producing the same results 
+;;         (gene/gene-ontology db (:id params) (str "rest/widget/gene/" (:id params) "/gene_ontology"))) ;; substancially same structure. not producing the same results
 ;;     (GET "/rest/widget/gene/:id/expression" {params :params}
 ;;         (gene/expression db (:id params) (str "rest/widget/gene/" (:id params) "/expression"))) ;; This one is predominantly done but needs a little checking and sequence data
 ;;     (GET "/rest/widget/gene/:id/homology" {params :params}
@@ -69,7 +69,7 @@
 (defn init []
   (print "Making Connection\n")
   (mount/start))
-  
+
 (defn app [request]
   (let [db (d/db datomic-conn)
         handler (app-routes db)]

--- a/src/datomic_rest_api/helpers.clj
+++ b/src/datomic_rest_api/helpers.clj
@@ -3,14 +3,14 @@
 
 (defn format-date
   [date-str]
-   (.format 
-     (java.text.SimpleDateFormat. "yyyy-M-dd") 
+   (.format
+     (java.text.SimpleDateFormat. "yyyy-M-dd")
         date-str))
 
 (defn format-date2
   [date-str]
-   (.format 
-     (java.text.SimpleDateFormat. "yyyy-M-dd") 
+   (.format
+     (java.text.SimpleDateFormat. "yyyy-M-dd")
       (.parse
       (java.text.SimpleDateFormat. "yyyy-MM-dd'T'HH:mm:ssZ")
         (str date-str))))
@@ -19,11 +19,8 @@
   [date-str]
    (if (= date-str "")
      date-str
-     (.format 
-       (java.text.SimpleDateFormat. "yyyy-M-dd") 
+     (.format
+       (java.text.SimpleDateFormat. "yyyy-M-dd")
         (.parse
         (java.text.SimpleDateFormat. "EEE MMM dd HH:mm:ss Z yyyy")
           date-str))))
-
-
-

--- a/src/datomic_rest_api/rest/gene.clj
+++ b/src/datomic_rest_api/rest/gene.clj
@@ -11,7 +11,7 @@
 ;; Currently gene-specific, make more general in the future?
 
 (defmacro def-rest-widget
-  "Define a handler for a rest widget endpoint.  `body` is executed with `gene-binding` 
+  "Define a handler for a rest widget endpoint.  `body` is executed with `gene-binding`
    will bound to the gene's entity-map, and should return a map of field values."
   [name [gene-binding] & body]
   `(defn ~name [db# id# uri#]
@@ -29,7 +29,7 @@
         :body (format "Can't find gene %s" id#)})))
 
 (defmacro def-rest-widget2
-  "Define a handler for a rest widget endpoint.  `body` is executed with `gene-binding` 
+  "Define a handler for a rest widget endpoint.  `body` is executed with `gene-binding`
    will bound to the gene's entity-map, and should return a map of field values."
   [name [gene-binding] & body]
   `(defn ~name [db# id# uri#]
@@ -80,7 +80,7 @@
   (some transcript-types (keys transcript)))
 
 (defn- gene-classification [gene]
- (let [data 
+ (let [data
    (let [db   (d/entity-db gene)
          cds  (:gene/corresponding-cds gene)
          data {:defined_by_mutation (if (not (empty? (:variation.gene/_gene gene))) 1 0)
@@ -93,7 +93,7 @@
                                   [?hist :gene-history-action/transposon-in-origin ?trans]]
                          db (:db/id gene))
                       "Transposon in origin"
-                         
+
                       (:gene/corresponding-pseudogene gene)
                       "pseudogene"
 
@@ -147,12 +147,12 @@
    :description "Operon the gene is contained in"})
 
 (defn- gene-cluster [gene]
-   {:data 
+   {:data
      (if-let [data (->> (:gene/main-name/text gene))] data)
     :description "The gene cluster for this gene"})
 
 (defn- gene-other-names [gene]
-   {:data (if-let [data (map #(get % "gene.other-name/text") (:gene/other-name gene))] 
+   {:data (if-let [data (map #(get % "gene.other-name/text") (:gene/other-name gene))]
              data)
     :description (format "other names that have been used to refer to %s" (:gene/id gene))})
 
@@ -500,7 +500,7 @@
                 (seq
                  (map :phenotype-info.remark/text
                       (:phenotype-info/remark holder))))}))
-          
+
           "RNAi:"
           (if-let [rp (seq (rnai-phenos pid))]
             (for [r rp
@@ -524,7 +524,7 @@
                 :Paper (if-let [paper (:rnai/reference rnai)]
                          (evidence-paper paper)))})))}])
      (into {}))))
-      
+
 
 (defn- phenotype-by-interaction [db gid]
   (let [table (q '[:find ?pheno (distinct ?int) ?int-type
@@ -552,7 +552,7 @@
    (map (fn [[pheno pints int-type]]
           {:interaction_type
            (datomic-rest-api.rest.object/humanize-ident int-type)
-           
+
            :phenotype
            (phenos pheno)
 
@@ -564,7 +564,7 @@
         table)
    :description
    "phenotype based on interaction"}))
-        
+
 (defn drives-overexpression [gene]
   (let [db (d/entity-db gene)]
    {:data  (->> (q '[:find [?cons ...]
@@ -577,7 +577,7 @@
 ]
              db (:db/id gene))
             (seq))
-          
+
     :description "phenotypes due to overexpression under the promoter of this gene"}))
 
 (defn- phenotype-overexpression [db gene]
@@ -643,7 +643,7 @@
 ;;                (seq
 ;;                 (map :phenotype-info.remark/text
 ;;                      (:phenotype-info/remark holder))))}))
-;;          
+;;
 ;;          "RNAi:"
 ;;          (if-let [rp (seq (rnai-phenos pid))]
 ;;            (for [r rp
@@ -667,8 +667,8 @@
 ;;                :Paper (if-let [paper (:rnai/reference rnai)]
 ;;                         (evidence-paper paper)))})))}])
 ;;     (into {}))))
-;; 
-         
+;;
+
 (def-rest-widget phenotypes [gene]
   {
    :name      (name-field gene)
@@ -681,10 +681,10 @@
 ;    {:Phenotype              (phenotype-table (d/entity-db gene) (:db/id gene) false)
 ;     :Phenotype_not_observed (phenotype-table (d/entity-db gene) (:db/id gene) true)}
 ;   :description "The phenotype summary of the gene"}
-        
+
 ;   :phenotype_by_interaction
 ;   (phenotype-by-interaction (d/entity-db gene) (:db/id gene))})
-   })        
+   })
 ;;
 ;; Mapping data widget
 ;;
@@ -756,9 +756,9 @@
            :result    (map #(or (items (str/replace % #"\." ""))
                                 (str % " "))
                            result)})
-           
+
           ))))
-          
+
 (defn gene-mapping-multipt
   [db id]
   (->> (q '[:find [?mp ...]
@@ -792,7 +792,7 @@
                                   (let [obj (:multi-counts/gene node)]
                                     (recur obj (conj res [(:multi-counts.gene/gene obj)
                                                           (:multi-counts.gene/int obj)])))
-                                  
+
                                   :default res))
                            tot (->> (map second res)
                                     (filter identity)
@@ -802,8 +802,8 @@
                        (->>
                         (mapcat
                          (fn [[obj count]]
-                           [(if (and (= @open-paren 0) (= count 0) (< @sum tot)) 
-                              (do 
+                           [(if (and (= @open-paren 0) (= count 0) (< @sum tot))
+                              (do
                                 (swap! open-paren inc)
                                 "("))
                             (datomic-rest-api.rest.object/pack-obj obj)
@@ -853,9 +853,9 @@
        (for [d (:gene/disease-experimental-model gene)]
          (assoc (datomic-rest-api.rest.object/pack-obj (:gene.disease-experimental-model/do-term d))
            :ev (datomic-rest-api.rest.object/get-evidence d))))
-        
+
       :gene
-      (seq 
+      (seq
        (q '[:find [?o ...]
             :in $ ?gene
             :where [?gene :gene/database ?dbent]
@@ -867,7 +867,7 @@
           db (:db/id gene)))
 
       :disease
-      (seq 
+      (seq
        (q '[:find [?o ...]
             :in $ ?gene
             :where [?gene :gene/database ?dbent]
@@ -877,7 +877,7 @@
                    [?dbent :gene.database/field ?field]
                    [?dbent :gene.database/accession ?o]]
           db (:db/id gene)))}}))
-       
+
 
 (def-rest-widget human-diseases [gene]
   {:name                    (name-field gene)
@@ -901,7 +901,7 @@
          :seq-id   (:db/id parent)
          :min      min
          :max      max}))))
-      
+
 
 ;;
 ;; Reagents widget
@@ -914,7 +914,7 @@
 (defn- transgene-labs [tg]
   (seq (map #(datomic-rest-api.rest.object/pack-obj "laboratory" (:transgene.laboratory/laboratory %))
             (:transgene/laboratory tg))))
-  
+
 
 (defn- transgene-record [construct]
   (let [base {:construct (datomic-rest-api.rest.object/pack-obj "construct" construct)
@@ -936,7 +936,7 @@
                     :use_summary (:transgene.summary/text (:transgene/summary t))
                     :used_in     (datomic-rest-api.rest.object/pack-obj "transgene" t)
                     :use_lab     (or (transgene-labs t)
-                                     (construct-labs construct) 
+                                     (construct-labs construct)
                                       [])))
 
       (:construct/engineered-variation construct)
@@ -957,7 +957,7 @@
           (mapcat transgene-record)
           (seq))
      :description "transgenes expressed by this gene"}))
-                      
+
 (defn- transgene-products [gene]
   (let [db (d/entity-db gene)]
     {:data
@@ -1011,7 +1011,7 @@
           (map #(datomic-rest-api.rest.object/pack-obj "sequence" (entity db %)))
           (seq))
      :description "cDNAs matching this gene"}))
-             
+
 (defn- antibodies [gene]
   (let [db (d/entity-db gene)]
     {:data
@@ -1039,7 +1039,7 @@
                                                                    [(<= ?cmin ?max)]
                                                                    [(>= ?cmax ?min)]]])
 
-(def ^:private child-rule  
+(def ^:private child-rule
   '[[(child ?parent ?min ?max ?method ?c) [?parent :sequence/id ?seq-name]
                                           [(pseudoace.binning/bins ?seq-name ?min ?max) [?bin ...]]
                                           [?c :locatable/murmur-bin ?bin]
@@ -1060,11 +1060,11 @@
      ;; once we're a bit more solid about how this stuff should work.
      ;;
      (if parent
-       (->> (q '[:find [?p ...] 
-                 :in $ % ?seq ?min ?max 
-                 :where [?method :method/id "Orfeome"] 
+       (->> (q '[:find [?p ...]
+                 :in $ % ?seq ?min ?max
+                 :where [?method :method/id "Orfeome"]
                         (or-join [?seq ?min ?max ?method ?p]
-                          (and         
+                          (and
                             [?ss-seq :locatable/assembly-parent ?seq]
                             [?ss-seq :locatable/min ?ss-min]
                             [?ss-seq :locatable/max ?ss-max]
@@ -1091,11 +1091,11 @@
         [parent start end] (root-segment gene)]
     {:data
      (if parent
-       (->> (q '[:find [?p ...] 
-                 :in $ % ?seq ?min ?max 
-                 :where [?method :method/id "GenePairs"] 
+       (->> (q '[:find [?p ...]
+                 :in $ % ?seq ?min ?max
+                 :where [?method :method/id "GenePairs"]
                         (or-join [?seq ?min ?max ?method ?p]
-                          (and         
+                          (and
                             [?ss-seq :locatable/assembly-parent ?seq]
                             [?ss-seq :locatable/min ?ss-min]
                             [?ss-seq :locatable/max ?ss-max]
@@ -1172,12 +1172,12 @@
         (map (partial datomic-rest-api.rest.object/pack-obj "phenotype") (:go-annotation/phenotype anno))
         ;; Also DB fields...
         ))
-        
-      
+
+
       :evidence_code
       {:text
        (:go-code/id code)
-       
+
        :evidence
        (vmap
         :Date_last_updated
@@ -1221,7 +1221,7 @@
                 mol :go-annotation.molecule-relation/molecule}
                (:go-annotation/molecule-relation anno)]
            [rel (datomic-rest-api.rest.object/pack-obj "molecule" mol)]))
-        (reduce 
+        (reduce
          (fn [m [rel obj]]
            (assoc m rel obj))
          nil)))])
@@ -1270,7 +1270,7 @@
 
        :term_id
        (datomic-rest-api.rest.object/pack-obj "go-term" term :label (:go-term/id term))
-       
+
        :term_description
        (datomic-rest-api.rest.object/pack-obj "go-term" term)}))))
 
@@ -1296,7 +1296,7 @@
        [(division-names key)
         (term-summary-table db annos)]))
     (into {}))
-   
+
    :description
    "gene ontology associations"}))
 
@@ -1349,7 +1349,7 @@
                   (not
                     [?ep :expr-pattern/tiling-array _])]
          db (:db/id gene))
-      (map 
+      (map
        (fn [ep-id]
          (let [ep (entity db ep-id)]
            (vmap
@@ -1400,10 +1400,10 @@
                       :evidence {:Construction_summary cs}}
                      packed)))
                (:expr-pattern/construct ep)))))
-                   
+
            )))
      :description (format "expression patterns associated with the gene:%s" (:gene/id gene))}))
-              
+
 
 (defn- expression-clusters [gene]
   (let [db (d/entity-db gene)]
@@ -1428,14 +1428,14 @@
 
 (defn- anatomy-function [gene]
   (let [db (d/entity-db gene)]
-   {:data 
+   {:data
     (->>
      (q '[:find [?af ...]
           :in $ ?gene
           :where [?afg :anatomy-function.gene/gene ?gene]
                  [?af :anatomy-function/gene ?afg]]
         db (:db/id gene))
-      (map 
+      (map
        (fn [af-id]
         (let [af (entity db af-id)]
            {:anatomy-function (datomic-rest-api.rest.object/pack-obj "expression-cluster" af)})))) ;; need to still make this packed object - so far have not seen an exmample of it filled in
@@ -1444,7 +1444,7 @@
 ;; I haven't found an example for this to show that it works
 (defn- curated-images [ep]
  (let [images (:picture/expr_pattern ep)]
-     (map 
+     (map
       (fn [image]
         (datomic-rest-api.rest.object/pack-obj "picture" image))
             images)))
@@ -1461,9 +1461,9 @@
       (map
        (fn [ep-id]
         (let [ep (entity db ep-id)]
-          {;;:data-test {:id (:expr-pattern/id ep) 
+          {;;:data-test {:id (:expr-pattern/id ep)
   ;;                    :gene (:expr-pattern/gene ep) }
-  ;;                    :rnaseq (:expr-pattern/rnaseq ep) 
+  ;;                    :rnaseq (:expr-pattern/rnaseq ep)
     ;;                  :pattern (:expr-pattern/pattern ep)
       ;;                :reference (:expr-pattern/reference ep)}
 ;;           :data (keys ep)
@@ -1472,7 +1472,7 @@
            :expressed_in nil
            :expression_pattern {:class "expr_pattern"
                                 :curated_images (curated-images ep) ;; should be array of pack-obj (datomic-rest-api.rest.object/pack-obj "picture )
-                                :id (:expr-pattern/id ep) 
+                                :id (:expr-pattern/id ep)
                                 :label (:expr-pattern/id ep)
                                 :taxonomy "all"}
            :go_term (first (:expr-pattern/go-term ep)) ;; need to see example
@@ -1505,10 +1505,10 @@
 
               :test
                    (expr-pattern-type ep)
- 
-              :details 
+
+              :details
                 (:expr-pattern/pattern ep)
- 
+
               :object "movie")))))
 
     :description "interactive 4D expression movies"}))
@@ -1667,9 +1667,9 @@
        "best BLASTP hits from selected species"}
       {:data         nil
        :description  "no proteins found, no best blastp hits to display"})))
-                          
-           
-                      
+
+
+
 (def nematode-species
   ["Ancylostoma ceylanicum"
    "Ascaris suum"
@@ -1706,7 +1706,7 @@
    :paralogs            (homology-paralogs gene)
    :best_blastp_matches (best-blastp-matches gene)
    :protein_domains     (protein-domains gene)})
-   
+
 ;;
 ;; History widget
 ;;
@@ -1747,7 +1747,7 @@
            (if-let [info (:gene-history-action/merged-into h)]
              (assoc result :action "Merged_into"
                     :gene (datomic-rest-api.rest.object/pack-obj "gene" info)))
-           
+
            (if-let [info (:gene-history-action/acquires-merge h)]
              (assoc result :action "Acquires_merge"
                     :gene (datomic-rest-api.rest.object/pack-obj "gene" info)))
@@ -1755,7 +1755,7 @@
            (if-let [info (:gene-history-action/split-from h)]
              (assoc result :action "Split_from"
                     :gene (datomic-rest-api.rest.object/pack-obj "gene" info)))
-           
+
            (if-let [info (:gene-history-action/split-into h)]
              (assoc result :action "Split_into"
                     :gene (datomic-rest-api.rest.object/pack-obj "gene" info)))
@@ -1864,16 +1864,16 @@
               (vmap
                :model
                (map datomic-rest-api.rest.object/pack-obj seqs)
-               
+
                :protein
                (datomic-rest-api.rest.object/pack-obj "protein" protein)
-                
+
                :cds
                (vmap
                 :text (vassoc (datomic-rest-api.rest.object/pack-obj "cds" cds) :footnotes footnotes)
                 :evidence (if (not (empty? status))
                             {:status status}))
-               
+
                :length_spliced
                (if coding?
                  (if-let [exons (seq (:cds/source-exons cds))]
@@ -1891,10 +1891,10 @@
                   (if (and (:locatable/max s) (:locatable/min s))
                     (- (:locatable/max s) (:locatable/min s))
                     "-")))
-               
+
                :length_protein
                (:protein.peptide/length (:protein/peptide protein))
-             
+
                :type (if seqs
                        (if-let [mid (:method/id
                                      (or (:transcript/method sequence)
@@ -1909,9 +1909,9 @@
                      (into (sorted-map)
                            (for [[r n] remark-map]
                              [n r])))))))
-                       
-                        
-           
+
+
+
      :description
      "gene models for this gene"}))
 
@@ -1985,7 +1985,7 @@
                    "HISTONE_BINDING_SITES"
                    "TRANSCRIPTION_FACTOR_BINDING_REGION"
                    "TRANSCRIPTION_FACTOR_BINDING_SITE"
-                   "BINDING_SITES_PREDICTED" 
+                   "BINDING_SITES_PREDICTED"
                    "BINDING_SITES_CURATED"
                    "BINDING_REGIONS"]}
    :description "The genomic location of the sequence to be displayed by GBrowse"})
@@ -2030,13 +2030,13 @@
                                  (= (count (:gene/_strain %)) 1)
                                  (is-cgc? %))
                            strains))
-      
+
       :carrying_gene_alone
       (strain-list (filter #(and (not (seq (:transgene/_strain %)))
                                  (= (count (:gene/_strain %)) 1)
                                  (not (is-cgc? %)))
                            strains))
-      
+
       :available_from_cgc
       (strain-list (filter #(and (or (seq (:transgene/_strain %))
                                      (not= (count (:gene/_strain %)) 1))
@@ -2071,7 +2071,7 @@
    (if (:variation/transposon-insertion var)
      "transposon insertion"
      (str/join ", "
-      (or 
+      (or
        (those
         (if (:variation/engineered-allele var)
           "Engineered allele")
@@ -2100,7 +2100,7 @@
    (cond
     (:variation/substitution var)
     "Substitution"
-    
+
     (:variation/insertion var)
     "Insertion"
 
@@ -2165,7 +2165,7 @@
           :when (or (:molecular-change/missense cc)
                     (nonsense cc))]
       (datomic-rest-api.rest.object/pack-obj "cds" (:variation.predicted-cds/cds cc))))
-          
+
    :phen_count
    (count (:variation/phenotype var))
 

--- a/src/datomic_rest_api/rest/interactions.clj
+++ b/src/datomic_rest_api/rest/interactions.clj
@@ -12,7 +12,7 @@
    :interactor-info.interactor-type/cis-regulatory     :effector
    :interactor-info.interactor-type/trans-regulated    :affected
    :interactor-info.interactor-type/cis-regulated      :affected})
-   
+
 
 (def ^:private interactor-target
   (some-fn
@@ -65,7 +65,7 @@
            affecteds :affected
            others :other
            associated :associated-product}
-          (group-by interactor-role (concat 
+          (group-by interactor-role (concat
                                      (:interaction/interactor-overlapping-cds int)
                                      (:interaction/interactor-overlapping-gene int)
                                      (:interaction/interactor-overlapping-protein int)
@@ -109,7 +109,7 @@
                                    [?int :interaction/interactor-overlapping-gene ?ih]]
     [(gene-neighbour ?gene ?neighbour) (gene-interaction ?gene ?ix)
                                        [?ix :interaction/interactor-overlapping-gene ?ih]
-                                       (not 
+                                       (not
                                         [?ix :interaction/type :interaction.type/predicted])
                                        [?ih :interaction.interactor-overlapping-gene/gene ?neighbour]
                                        [(not= ?gene ?neighbour)]]
@@ -136,12 +136,12 @@
           db int-rules gene)
        (filter (fn [[_ cnt]] (> cnt 1)))
        (map first)))
-            
+
 
 (defn gene-interactions [obj nearby?]
   (let [db (d/entity-db obj)
         id (:db/id obj)]
-    (map 
+    (map
      (partial entity db)
      (concat
       (gene-direct-interactions db id)
@@ -161,8 +161,8 @@
                      ((some-fn :molecule/id :gene/id :rearrangement/id :feature/id) affected))
               (let [ename (:label (pack-obj effector))
                     aname (:label (pack-obj affected))
-                    phenotype (pack-obj 
-                               "phenotype" 
+                    phenotype (pack-obj
+                               "phenotype"
                                (first (:interaction/interaction-phenotype interaction))) ;; warning: could be more than one.
                     key1 (str ename " " aname " " type " " (:label phenotype))   ; interactions with the same endpoints but
                     key2 (str aname " " ename " " type " " (:label phenotype))   ; a different phenotype get a separate row.
@@ -172,12 +172,12 @@
                     pack-affected (pack-obj affected)
                     data (-> data
                              ;; Check how "predicted" flags are supposed to compose
-                             (assoc-in [:nodes (:id pack-effector)] (vassoc pack-effector 
+                             (assoc-in [:nodes (:id pack-effector)] (vassoc pack-effector
                                                                        :predicted (if (= type "Predicted") 1 0)
                                                                        :main (if (= effector obj) 1)))
-                             (assoc-in [:nodes (:id pack-affected)] (vassoc pack-affected 
+                             (assoc-in [:nodes (:id pack-affected)] (vassoc pack-affected
                                                                        :predicted (if (= type "Predicted") 1 0)
-                                                                       :main (if (= affected obj) 1))) 
+                                                                       :main (if (= affected obj) 1)))
                              (assoc-in [:types type] 1)
                              (assoc-in [:ntypes (:class pack-effector)] 1)
                              (assoc-in [:ntypes (:class pack-affected)] 1)
@@ -188,12 +188,12 @@
                   (-> data
                       (update-in [:edges key1 :interactions] conj pack-int)
                       (update-in [:edges key1 :citations] into papers))
-                  
+
                   (get-in data [:edges key2])
                   (-> data
                       (update-in [:edges key2 :interactions] conj pack-int)
                       (update-in [:edges key2 :citations] into papers))
-                  
+
                   :default
                   (assoc-in data [:edges key1]
                             {:interactions [pack-int]

--- a/src/datomic_rest_api/rest/locatable_api.clj
+++ b/src/datomic_rest_api/rest/locatable_api.clj
@@ -26,7 +26,7 @@
                               :locatable.strand/positive
                               [(+ tmin emin -1)
                                (+ tmin emax)]
-                              
+
                               :locatable.strand/negative
                               [(- tmax emax)
                                (- tmax emin -1)])]
@@ -82,7 +82,7 @@
     (noncoding-transcript-structure t tmin tmax)))
 
 (defn get-features [db type parent min max]
-  (->> 
+  (->>
    (features db type (:db/id parent) min max)
    (map
     (fn [[fid min max]]
@@ -99,14 +99,14 @@
          :subfeatures (if (:transcript/id feature)
                         (transcript-structure feature min max))
          ))))))
-        
+
 
 (defn json-features [db {:keys [type id] :strs [start end]}]
   (if-let [parent (entity db [:sequence/id id])]
     (let [start            (parse-int start)
           end              (parse-int end)
-          [parent min max] (root-segment parent 
-                                         (or start 1) 
+          [parent min max] (root-segment parent
+                                         (or start 1)
                                          (or end (seq-length parent)))]
       {:status 200
        :content-type "application/json"
@@ -127,8 +127,8 @@
   (if-let [parent (entity db [:sequence/id id])]
     (let [start            (parse-int start)
           end              (parse-int end)
-          [parent min max] (root-segment parent 
-                                         (or start 1) 
+          [parent min max] (root-segment parent
+                                         (or start 1)
                                          (or end (seq-length parent)))
           features         (get-features db type parent min max)]
       {:status 200
@@ -145,8 +145,8 @@
   (if-let [parent (entity db [:sequence/id id])]
     (let [reg-start        (parse-int start)
           reg-end          (parse-int end)
-          [parent rmin rmax] (root-segment parent 
-                                         (or reg-start 1) 
+          [parent rmin rmax] (root-segment parent
+                                         (or reg-start 1)
                                          (or reg-end (seq-length parent)))
           bin-size         (or (parse-int bin-size)
                                (max 10 (quot (- rmax rmin) 50)))
@@ -170,8 +170,8 @@
                :stats {:max (reduce max counts)
                        :basesPerBin bin-size}}
               {:pretty true})})))
-          
-(def feature-api 
+
+(def feature-api
   (routes
    (GET "/:type/features/:id" {params :params db :db}
         (json-features db params))

--- a/src/datomic_rest_api/rest/object.clj
+++ b/src/datomic_rest_api/rest/object.clj
@@ -16,7 +16,7 @@
   (entity db [(keyword class "id") id]))
 
 (defn obj-tax [class obj]
-  "If entity-map `obj` has a species attribute, return the short name of the 
+  "If entity-map `obj` has a species attribute, return the short name of the
    species, otherwise \"all\"."
   (let [species-ident (keyword class "species")]
     (if-let [species (species-ident obj)]
@@ -149,18 +149,18 @@
           (cond
            (string? interactor)
            interactor
-           
+
            :default
            (:label (pack-obj (entity db interactor)))))
         il)
        (sort)
        (str/join " : "))
       (:interaction/id int))))
-                  
-                  
+
+
 (defmethod obj-label "motif" [_ motif]
   (or (first (:motif/title motif))
-      (:motif/id motif)))        
+      (:motif/id motif)))
 
 (defmethod obj-label :default [class obj]
   ((keyword class "id") obj))
@@ -171,7 +171,7 @@
 
 (defmethod obj-name "gene" [class db id]
   (let [obj (obj-get class db id)]
-    {:data 
+    {:data
      {:id    (:gene/id obj)
        :label (or (:gene/public-name obj)
                 (:gene/id obj))
@@ -194,7 +194,7 @@
 
    (:protein/id obj)
    "protein"
-   
+
    (:feature/id obj)
    "feature"
 
@@ -220,8 +220,8 @@
      {:id       ((keyword class "id") obj)
       :label    (or label
                   (obj-label class obj))
-      :class  (if class 
-                (if (= class "author") 
+      :class  (if class
+                (if (= class "author")
                   "person"
                   (str/replace class "-" "_")))
       :taxonomy (obj-tax class obj)})))
@@ -229,7 +229,7 @@
 (defn get-evidence [holder]
   ;; Some of these need further checking to ensure that handling of multiple
   ;; values matches Perl.
-  
+
   (vmap-if
    :Inferred_automatically
    (seq
@@ -244,14 +244,14 @@
    (seq
     (for [person (:evidence/person-evidence holder)]
       (pack-obj "person" person)))
-   
+
    :Paper_evidence
    (seq
     (for [paper (:evidence/paper-evidence holder)]
       (pack-obj "paper" paper)))
 
-   :Date_last_updated 
-   (if-let [date (:evidence/date-last-updated holder)]     
+   :Date_last_updated
+   (if-let [date (:evidence/date-last-updated holder)]
        [{ :id (str (.format (java.text.SimpleDateFormat. "yyyy-M-dd") date))
          :label (str (.format (java.text.SimpleDateFormat. "yyyy-M-dd") date))
          :class "text"}])
@@ -277,7 +277,7 @@
        {:id acc
         :label (format "%s:%s" (:database/id db) acc)
         :class (:database/id acc)}))
-       
+
 
    :Protein_id_evidence
    (seq
@@ -328,7 +328,7 @@
    :Sequence_evidence
    (if-let [seqs (:evidence/sequence-evidence holder)]
      (map (partial pack-obj "sequence" seqs)))))
-  
+
 
 (defn humanize-ident
   "Reconstruct a more human-readable representation of a Datomic enum key."

--- a/src/datomic_rest_api/rest/references.clj
+++ b/src/datomic_rest_api/rest/references.clj
@@ -33,4 +33,3 @@
                :query id
                :type "paper"
                :results (map format-paper (take 1000 refs))})})))   ;; Should do some pagination?
-               


### PR DESCRIPTION
Hi @mgrbyte , I fixed [feature/add-genetics](https://github.com/WormBase/datomic-to-catalyst/tree/feature/add-genetics) as you suggested. So commit that fixes whitespaces come first (earliest), followed by my feature commits (later in time). Here is a timeline of the commits: fixed https://github.com/WormBase/datomic-to-catalyst/pull/30/commits.

So I created this branch with trailing whitespace fix ONLY, so you can merge it into develop first. Then you can compare more easily feature/add-genetics to develop. Hope this works. 

Thanks!