### PR TITLE
Feature/refactor controller

### DIFF
--- a/src/datomic_rest_api/get_handler.clj
+++ b/src/datomic_rest_api/get_handler.clj
@@ -41,8 +41,8 @@
                   </html>")
      (GET "/rest/widget/:class/:id/:widget" [class id widget :as request]
           (handle-widget-get db class id widget request))
-     (GET "/rest/field/:class/:id/:field" [class id field]
-          (handle-field-get db class id field))))
+     (GET "/rest/field/:class/:id/:field" [class id field :as request]
+          (handle-field-get db class id field request))))
 
 
 (defn init []
@@ -97,7 +97,8 @@
     (let [wrapped-field-fn (wrap-field field-fn)
           data (wrapped-field-fn db class id)]
       (-> {:name id
-           :class class}
+           :class class
+           :url (:uri request)}
           (assoc (keyword field-name) data)
           (wrap-response)))
     (-> {:message "field not exist or not available to public"}

--- a/src/datomic_rest_api/get_handler.clj
+++ b/src/datomic_rest_api/get_handler.clj
@@ -73,13 +73,6 @@
       (ring.util.response/response)
       (ring.util.response/content-type "application/json")))
 
-;; REST field handler and helper
-
-;; (defn- wrap-field [field-fn]
-;;   (fn [db class id]
-;;     (let [wbid-field (str class "/id")]
-;;       (field-fn (d/entity db [(keyword wbid-field) id])))))
-
 (defn- resolve-endpoint [class endpoint-name whitelist]
   (if-let [fn-name (-> (str/join "/" [class endpoint-name])
                        (str/replace "_" "-")
@@ -97,6 +90,8 @@
   #{"gene/alleles-other"
     "gene/polymorphisms"})
 
+;; start of REST handler for widgets and fields
+
 (defn- handle-field-get [db class id field-name request]
   (if-let [field-fn (resolve-endpoint class field-name whitelisted-fields)]
     (let [wrapped-field-fn (wrap-field field-fn)
@@ -108,8 +103,6 @@
     (-> {:message "field not exist or not available to public"}
         (wrap-response)
         (ring.util.response/status 404))))
-;; END of REST field
-
 
 (defn- handle-widget-get [db class id widget-name request]
   (if-let [widget-fn (resolve-endpoint class widget-name whitelisted-widgets)]
@@ -125,3 +118,5 @@
                           (str/capitalize class))}
         (wrap-response)
         (ring.util.response/status 404))))
+
+;; END of REST handler for widgets and fields

--- a/src/datomic_rest_api/rest/core.clj
+++ b/src/datomic_rest_api/rest/core.clj
@@ -4,12 +4,12 @@
             [clojure.string :as str]))
 
 
-(defn wrap-field [field-fn]
+(defn field-adaptor [field-fn]
   (fn [db class id]
     (let [wbid-field (str class "/id")]
       (field-fn (d/entity db [(keyword wbid-field) id])))))
 
-(defn wrap-widget [widget-fn]
+(defn widget-adaptor [widget-fn]
   (fn [db class id]
     (let [wbid-field (str class "/id")]
       (widget-fn (d/entity db [(keyword wbid-field) id])))))

--- a/src/datomic_rest_api/rest/core.clj
+++ b/src/datomic_rest_api/rest/core.clj
@@ -1,0 +1,71 @@
+(ns datomic-rest-api.rest.core
+  (:require [datomic.api :as d :refer (db q touch entity)]
+            [cheshire.core :as c :refer (generate-string)]
+            [clojure.string :as str]))
+
+
+(defn wrap-field [field-fn]
+  (fn [db class id]
+    (let [wbid-field (str class "/id")]
+      (field-fn (d/entity db [(keyword wbid-field) id])))))
+
+;; (defn wrap-widget [fields-map]
+;;   (reduce (fn [new-fields-map [field-key field-fn]]
+;;             (assoc new-fields-map
+;;                    field-key
+;;                    (wrap-field field-fn)))
+;;           {}
+;;           fields-map))
+
+(defn wrap-widget [widget-fn]
+  (fn [db class id]
+    (let [wbid-field (str class "/id")]
+      (widget-fn (d/entity db [(keyword wbid-field) id])))))
+
+(defmacro def-rest-widget
+  "def-rest-widget is synonymous to defn"
+  [name [binding] & body]
+  `(defn ~name [~binding]
+     (do ~@body)))
+
+
+
+;; (defmacro def-rest-widget
+;;   "Define a handler for a rest widget endpoint.  `body` is executed with `gene-binding`
+;;    will bound to the gene's entity-map, and should return a map of field values."
+;;   [name [gene-binding] & body]
+;;   `(defn ~name [db# class# id#]
+;;      (if-let [~gene-binding (entity db# [:gene/id id#])]
+;;        {:status 200
+;;         :content-type "application/json"
+;;         :body (generate-string
+;;                {:class "gene"
+;;                 :name id#
+;;                 :uri uri#
+;;                 :fields (do ~@body)}
+;;                {:pretty true})}
+;;        {:status 404
+;;         :content-type "text/plain"
+;;         :body (format "Can't find gene %s" id#)})
+;;      ))
+
+
+
+;; (defmacro def-rest-widget
+;;   "Define a handler for a rest widget endpoint.  `body` is executed with `gene-binding`
+;;    will bound to the gene's entity-map, and should return a map of field values."
+;;   [name [gene-binding] & body]
+;;   `(defn ~name [db# class# id#]
+;;      (if-let [~gene-binding (entity db# [:gene/id id#])]
+;;        {:status 200
+;;         :content-type "application/json"
+;;         :body (generate-string
+;;                {:class "gene"
+;;                 :name id#
+;;                 :uri uri#
+;;                 :fields (do ~@body)}
+;;                {:pretty true})}
+;;        {:status 404
+;;         :content-type "text/plain"
+;;         :body (format "Can't find gene %s" id#)})
+;;      ))

--- a/src/datomic_rest_api/rest/core.clj
+++ b/src/datomic_rest_api/rest/core.clj
@@ -1,6 +1,5 @@
 (ns datomic-rest-api.rest.core
-  (:require [datomic.api :as d :refer (db q touch entity)]
-            [cheshire.core :as c :refer (generate-string)]
+  (:require [datomic.api :as d]
             [clojure.string :as str]))
 
 

--- a/src/datomic_rest_api/rest/core.clj
+++ b/src/datomic_rest_api/rest/core.clj
@@ -9,14 +9,6 @@
     (let [wbid-field (str class "/id")]
       (field-fn (d/entity db [(keyword wbid-field) id])))))
 
-;; (defn wrap-widget [fields-map]
-;;   (reduce (fn [new-fields-map [field-key field-fn]]
-;;             (assoc new-fields-map
-;;                    field-key
-;;                    (wrap-field field-fn)))
-;;           {}
-;;           fields-map))
-
 (defn wrap-widget [widget-fn]
   (fn [db class id]
     (let [wbid-field (str class "/id")]
@@ -27,45 +19,3 @@
   [name [binding] & body]
   `(defn ~name [~binding]
      (do ~@body)))
-
-
-
-;; (defmacro def-rest-widget
-;;   "Define a handler for a rest widget endpoint.  `body` is executed with `gene-binding`
-;;    will bound to the gene's entity-map, and should return a map of field values."
-;;   [name [gene-binding] & body]
-;;   `(defn ~name [db# class# id#]
-;;      (if-let [~gene-binding (entity db# [:gene/id id#])]
-;;        {:status 200
-;;         :content-type "application/json"
-;;         :body (generate-string
-;;                {:class "gene"
-;;                 :name id#
-;;                 :uri uri#
-;;                 :fields (do ~@body)}
-;;                {:pretty true})}
-;;        {:status 404
-;;         :content-type "text/plain"
-;;         :body (format "Can't find gene %s" id#)})
-;;      ))
-
-
-
-;; (defmacro def-rest-widget
-;;   "Define a handler for a rest widget endpoint.  `body` is executed with `gene-binding`
-;;    will bound to the gene's entity-map, and should return a map of field values."
-;;   [name [gene-binding] & body]
-;;   `(defn ~name [db# class# id#]
-;;      (if-let [~gene-binding (entity db# [:gene/id id#])]
-;;        {:status 200
-;;         :content-type "application/json"
-;;         :body (generate-string
-;;                {:class "gene"
-;;                 :name id#
-;;                 :uri uri#
-;;                 :fields (do ~@body)}
-;;                {:pretty true})}
-;;        {:status 404
-;;         :content-type "text/plain"
-;;         :body (format "Can't find gene %s" id#)})
-;;      ))

--- a/src/datomic_rest_api/rest/gene.clj
+++ b/src/datomic_rest_api/rest/gene.clj
@@ -10,44 +10,6 @@
             [datomic-rest-api.rest.core :refer [def-rest-widget]]
             ))
 
-;; Currently gene-specific, make more general in the future?
-
-;; (defmacro def-rest-widget
-;;   "Define a handler for a rest widget endpoint.  `body` is executed with `gene-binding`
-;;    will bound to the gene's entity-map, and should return a map of field values."
-;;   [name [gene-binding] & body]
-;;   `(defn ~name [db# id# uri#]
-;;      (if-let [~gene-binding (entity db# [:gene/id id#])]
-;;        {:status 200
-;;         :content-type "application/json"
-;;         :body (generate-string
-;;                {:class "gene"
-;;                 :name id#
-;;                 :uri uri#
-;;                 :fields (do ~@body)}
-;;                {:pretty true})}
-;;        {:status 404
-;;         :content-type "text/plain"
-;;         :body (format "Can't find gene %s" id#)})))
-
-(defmacro def-rest-widget2
-  "Define a handler for a rest widget endpoint.  `body` is executed with `gene-binding`
-   will bound to the gene's entity-map, and should return a map of field values."
-  [name [gene-binding] & body]
-  `(defn ~name [db# id# uri#]
-     (if-let [~gene-binding (entity db# [:gene/id id#])]
-       {:status 200
-        :content-type "application/json"
-        :body (generate-string
-               {:class "gene"
-                :name id#
-                :uri uri#
-                :reagents (do ~@body)}
-               {:pretty true})}
-       {:status 404
-        :content-type "text/plain"
-        :body (format "Can't find gene %s" id#)})))
-
 ;;
 ;; "name" field, included on all widgets.
 ;;
@@ -1125,7 +1087,7 @@
    :description
    "SAGE tags identified"})
 
-(def-rest-widget2 reagents [gene]
+(def-rest-widget reagents [gene]
   {:name               (name-field gene)
    :transgenes         (transgenes gene)
    :transgene_products (transgene-products gene)

--- a/src/datomic_rest_api/rest/gene.clj
+++ b/src/datomic_rest_api/rest/gene.clj
@@ -6,27 +6,29 @@
             [datomic.api :as d :refer (db q touch entity)]
             [clojure.string :as str]
             [pseudoace.utils :refer [vmap vmap-if vassoc cond-let those conjv]]
-            [pseudoace.locatables :refer (root-segment)]))
+            [pseudoace.locatables :refer (root-segment)]
+            [datomic-rest-api.rest.core :refer [def-rest-widget]]
+            ))
 
 ;; Currently gene-specific, make more general in the future?
 
-(defmacro def-rest-widget
-  "Define a handler for a rest widget endpoint.  `body` is executed with `gene-binding`
-   will bound to the gene's entity-map, and should return a map of field values."
-  [name [gene-binding] & body]
-  `(defn ~name [db# id# uri#]
-     (if-let [~gene-binding (entity db# [:gene/id id#])]
-       {:status 200
-        :content-type "application/json"
-        :body (generate-string
-               {:class "gene"
-                :name id#
-                :uri uri#
-                :fields (do ~@body)}
-               {:pretty true})}
-       {:status 404
-        :content-type "text/plain"
-        :body (format "Can't find gene %s" id#)})))
+;; (defmacro def-rest-widget
+;;   "Define a handler for a rest widget endpoint.  `body` is executed with `gene-binding`
+;;    will bound to the gene's entity-map, and should return a map of field values."
+;;   [name [gene-binding] & body]
+;;   `(defn ~name [db# id# uri#]
+;;      (if-let [~gene-binding (entity db# [:gene/id id#])]
+;;        {:status 200
+;;         :content-type "application/json"
+;;         :body (generate-string
+;;                {:class "gene"
+;;                 :name id#
+;;                 :uri uri#
+;;                 :fields (do ~@body)}
+;;                {:pretty true})}
+;;        {:status 404
+;;         :content-type "text/plain"
+;;         :body (format "Can't find gene %s" id#)})))
 
 (defmacro def-rest-widget2
   "Define a handler for a rest widget endpoint.  `body` is executed with `gene-binding`
@@ -2285,7 +2287,7 @@
    :description "rearrangements involving this gene"})
 
 
-(def-rest-widget genetics [gene]
+(defn genetics [gene]
   {:reference_allele (reference-allele gene)
    :rearrangements   (rearrangements gene)
    :strains          (strains gene)


### PR DESCRIPTION
Hi @a8wright and @mgrbyte hope you guys have fun at Clojure conj. When you have time (no rush), here is a PR for you guys :-)

**tl;dr This is a refactor of the `get-handler.clj` and `def-rest-widget`, that is fully compatible with everything else that has been implemented.**

A couple things this PR does:
- make `def-rest-widget` more generic: you can import it from rest/core.clj and use it anywhere
- make `def-rest-widget` macro trivial: 
     - the complexity is split into helper functions: widget-adaptor and json-response
     - at the moment, `def-rest-widget` is roughly synonymous to a `defn` (you can in fact use `defn` to declare widgets, not recommended though for forward compatibility)
- remove hard coded routes in `get-handler.clj`
- include a whitelist for widgets and fields that is checked in the controller/handler

Things NOT resolved by this PR:
- answer question like: can you tell me the fields available in the Gene Overview widget, without instantiate it? This might require either change to how `def-rest-widget` is being **called**, and/or its implementation. 

Thank you!
