### PR TITLE
auto generated widget and field whitelist and index page

### DIFF
--- a/src/datomic_rest_api/get_handler.clj
+++ b/src/datomic_rest_api/get_handler.clj
@@ -10,9 +10,10 @@
             [ring.util.response :refer (redirect file-response)]
             [cheshire.core :as json :refer (parse-string)]
             [environ.core :refer (env)]
+            [hiccup.core :refer (html)]
             [mount.core :as mount]
             [datomic-rest-api.utils.db :refer (datomic-conn)]
-            [datomic-rest-api.rest.core :refer (field-adaptor widget-adaptor resolve-endpoint)]
+            [datomic-rest-api.rest.core :refer (field-adaptor widget-adaptor resolve-endpoint endpoint-urls)]
             [datomic-rest-api.rest.widgets.gene :as gene]))
 
 
@@ -20,34 +21,22 @@
 (declare handle-widget-get)
 
 (defn app-routes [db]
-   (routes
-     (GET "/" [] "<html>
-                    <h5>Widgets</h5>
-                    <ul>
-                       <li><a href=\"./rest/widget/\">/rest/widget/</a></li>
-                       <li><a href=\"./rest/field/\">/rest/field/</a></li>
-                    <ul>
-                  </html>")
-     (GET "/rest/field/" [] "<html>
-                            <ul>
-                              <li>/rest/field/gene/:id/alleles-other</li>
-                              <li>/rest/field/gene/:id/polymorphism</li>
-                            </ul>
-                            </html>")
-     (GET "/rest/widget/" [] "<html>
-                    <ul>
-                      <li>/rest/widget/gene/:id/external_links</li>
-                      <li>/rest/widget/gene/:id/overview</li>
-                      <li>/rest/widget/gene/:id/history</li>
-                      <li>/rest/widget/gene/:id/mapping_data</li>
-                      <li>/rest/widget/gene/:id/genetics</li>
-                      <li>/rest/widget/gene/:id/phenotype</li>
-                    </ul>
-                  </html>")
-     (GET "/rest/widget/:schema-name/:id/:widget-name" [schema-name id widget-name :as request]
-          (handle-widget-get db schema-name id widget-name request))
-     (GET "/rest/field/:schema-name/:id/:field-name" [schema-name id field-name :as request]
-          (handle-field-get db schema-name id field-name request))))
+  (routes
+   (GET "/" []
+        (html [:h5 "index"]
+              [:ul
+               [:li [:a {:href "/rest/field/"} "/rest/field/"]]
+               [:li [:a {:href "/rest/widget/"} "/rest/widget/"]]]))
+   (GET "/rest/field/" []
+        (html [:ul (->> (endpoint-urls "field")
+                        (map #(vector :li %)))]))
+   (GET "/rest/widget/" []
+        (html [:ul (->> (endpoint-urls "widget")
+                        (map #(vector :li %)))]))
+   (GET "/rest/widget/:schema-name/:id/:widget-name" [schema-name id widget-name :as request]
+        (handle-widget-get db schema-name id widget-name request))
+   (GET "/rest/field/:schema-name/:id/:field-name" [schema-name id field-name :as request]
+        (handle-field-get db schema-name id field-name request))))
 
 
 (defn init []

--- a/src/datomic_rest_api/get_handler.clj
+++ b/src/datomic_rest_api/get_handler.clj
@@ -12,7 +12,7 @@
             [environ.core :refer (env)]
             [mount.core :as mount]
             [datomic-rest-api.utils.db :refer (datomic-conn)]
-            [datomic-rest-api.rest.core :refer (field-adaptor widget-adaptor)]
+            [datomic-rest-api.rest.core :refer (field-adaptor widget-adaptor whitelist)]
             [datomic-rest-api.rest.widgets.gene :as gene]))
 
 
@@ -78,30 +78,21 @@
       (ring.util.response/response)
       (ring.util.response/content-type "application/json")))
 
-(defn- resolve-endpoint [schema-name endpoint-name whitelist]
-  (if-let [fn-name (-> (str/join "/" [schema-name endpoint-name])
-                       (str/replace "_" "-")
-                       (whitelist))]
-    (or (resolve (symbol (str "datomic-rest-api.rest.widgets." fn-name)))
-        (resolve (symbol (str "datomic-rest-api.rest.fields." fn-name))))))
+(defn- resolve-endpoint [scope schema-name endpoint-name]
+  (-> (str/join "." [scope schema-name endpoint-name])
+      (@whitelist)))
 
-(def ^{:private true} whitelisted-widgets
-  #{"gene/overview"
-    "gene/external-links"
-    "gene/genetics"
-    "gene/phenotype"
-    "gene/history"
-    "gene/mapping-data"})
-
-(def ^{:private true} whitelisted-fields
-  #{"gene/alleles-other"
-    "gene/polymorphisms"
-    "gene/fpkm-expression-summary-ls"})
+;; start of REST handler for widgets and fields
+(defn- json-response [data]
+  (-> data
+      (json/generate-string {:pretty true})
+      (ring.util.response/response)
+      (ring.util.response/content-type "application/json")))
 
 ;; start of REST handler for widgets and fields
 
 (defn- handle-field-get [db schema-name id field-name request]
-  (if-let [field-fn (resolve-endpoint schema-name field-name whitelisted-fields)]
+  (if-let [field-fn (resolve-endpoint "field" schema-name field-name)]
     (let [adapted-field-fn (field-adaptor field-fn)
           data (adapted-field-fn db schema-name id)]
       (-> {:name id
@@ -109,12 +100,12 @@
            :url (:uri request)}
           (assoc (keyword field-name) data)
           (json-response)))
-    (-> {:message "field not exist or not available to public"}
+    (-> {:message "field not exist or not available to public "}
         (json-response)
         (ring.util.response/status 404))))
 
 (defn- handle-widget-get [db schema-name id widget-name request]
-  (if-let [widget-fn (resolve-endpoint schema-name widget-name whitelisted-widgets)]
+  (if-let [widget-fn (resolve-endpoint "widget" schema-name widget-name)]
     (let [adapted-widget-fn (widget-adaptor widget-fn)
           data (adapted-widget-fn db schema-name id)]
       (-> {:name id
@@ -124,7 +115,8 @@
           (json-response)))
     (-> {:message (format "%s widget for %s not exist or not available to public"
                           (str/capitalize widget-name)
-                          (str/capitalize schema-name))}
+                          (str/capitalize schema-name))
+         :a (str/join "." ["widget" schema-name widget-name])}
         (json-response)
         (ring.util.response/status 404))))
 

--- a/src/datomic_rest_api/get_handler.clj
+++ b/src/datomic_rest_api/get_handler.clj
@@ -72,11 +72,6 @@
 ;; internal functions and helper ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn- json-response [data]
-  (-> data
-      (json/generate-string {:pretty true})
-      (ring.util.response/response)
-      (ring.util.response/content-type "application/json")))
 
 ;; start of REST handler for widgets and fields
 (defn- json-response [data]

--- a/src/datomic_rest_api/get_handler.clj
+++ b/src/datomic_rest_api/get_handler.clj
@@ -12,7 +12,7 @@
             [environ.core :refer (env)]
             [mount.core :as mount]
             [datomic-rest-api.utils.db :refer (datomic-conn)]
-            [datomic-rest-api.rest.core :refer (field-adaptor widget-adaptor whitelist)]
+            [datomic-rest-api.rest.core :refer (field-adaptor widget-adaptor resolve-endpoint)]
             [datomic-rest-api.rest.widgets.gene :as gene]))
 
 
@@ -78,10 +78,6 @@
       (ring.util.response/response)
       (ring.util.response/content-type "application/json")))
 
-(defn- resolve-endpoint [scope schema-name endpoint-name]
-  (-> (str/join "." [scope schema-name endpoint-name])
-      (@whitelist)))
-
 ;; start of REST handler for widgets and fields
 (defn- json-response [data]
   (-> data
@@ -115,8 +111,7 @@
           (json-response)))
     (-> {:message (format "%s widget for %s not exist or not available to public"
                           (str/capitalize widget-name)
-                          (str/capitalize schema-name))
-         :a (str/join "." ["widget" schema-name widget-name])}
+                          (str/capitalize schema-name))}
         (json-response)
         (ring.util.response/status 404))))
 

--- a/src/datomic_rest_api/rest/core.clj
+++ b/src/datomic_rest_api/rest/core.clj
@@ -17,7 +17,7 @@
 
 ;; helpers for managing whitelisted endpoints
 
-(def ^{:private true} whitelist (atom {}))
+(defonce ^{:private true} whitelist (atom {}))
 
 (defn- endpoint-key [scope schema-name endpoint-name]
   (-> (str/join "." [scope schema-name endpoint-name])
@@ -56,5 +56,17 @@
 (defmacro def-rest-widget
   [name body]
   `(register-widget (str (quote ~name)) ~body))
+
+
+(defn endpoint-urls [scope]
+  (->> (keys @whitelist)
+       (map #(str/split % #"\."))
+       (map #(zipmap [:scope :schema :name] %))
+       (filter #(= scope (:scope %)))
+       (map #(str/join "/" ["rest"
+                            (:scope %)
+                            (:schema %)
+                            :id
+                            (:name %)]))))
 
 ;; helpers for managing whitelisted endpoints

--- a/src/datomic_rest_api/rest/core.clj
+++ b/src/datomic_rest_api/rest/core.clj
@@ -13,14 +13,26 @@
     (let [wbid-field (str class "/id")]
       (widget-fn (d/entity db [(keyword wbid-field) id])))))
 
-(def whitelist (atom {}))
+(def ^{:private true} whitelist (atom {}))
 
-(defn register-endpoint [scope schema endpoint-fn endpoint-label]
-  (let [endpoint-key (-> (str/join "." [scope schema endpoint-label])
-                         (str/replace #"-" "_"))]
-    (swap! whitelist assoc endpoint-key endpoint-fn)))
+(defn- endpoint-key [scope schema-name endpoint-name]
+  (-> (str/join "." [scope schema-name endpoint-name])
+      (str/replace #"-" "_")))
 
-(defn rest-widget-fn [field-map]
+(defn resolve-endpoint [scope schema-name endpoint-name]
+  (-> (endpoint-key scope schema-name endpoint-name)
+      (@whitelist)))
+
+(defn register-endpoint [scope endpoint-fn endpoint-name]
+  (let [schema-name (-> (str *ns*)
+                        (str/split #"\.")
+                        (last))]
+    (swap! whitelist
+           assoc
+           (endpoint-key scope schema-name endpoint-name)
+           endpoint-fn)))
+
+(defn- rest-widget-fn [field-map]
   (fn [binding]
     (reduce (fn [result-map [key field-fn]]
               (assoc result-map key (field-fn binding)))
@@ -28,21 +40,13 @@
             field-map)))
 
 (defn register-widget [widget-name field-map]
-  (let [schema-name (-> (str *ns*)
-                        (str/split #"\.")
-                        (last))]
-    (do (register-endpoint "widget" schema-name (rest-widget-fn field-map) widget-name)
-        (doseq [[key field-fn] field-map]
-          (register-endpoint "field" schema-name field-fn (name key)))
-        (println (keys @whitelist)))))
+  (do (register-endpoint "widget" (rest-widget-fn field-map) widget-name)
+      (doseq [[key field-fn] field-map]
+        (register-endpoint "field" field-fn (name key)))))
+
+(defn register-independent-field [field-name field-fn]
+  (register-endpoint "field" field-fn field-name))
 
 (defmacro def-rest-widget
   [name body]
   `(register-widget (str (quote ~name)) ~body))
-
-
-;; (defmacro def-rest-widget
-;;   "def-rest-widget is synonymous to defn"
-;;   [name [binding] & body]
-;;   `(defn ~name [~binding]
-;;      (do ~@body)))

--- a/src/datomic_rest_api/rest/core.clj
+++ b/src/datomic_rest_api/rest/core.clj
@@ -13,6 +13,10 @@
     (let [wbid-field (str class "/id")]
       (widget-fn (d/entity db [(keyword wbid-field) id])))))
 
+
+
+;; helpers for managing whitelisted endpoints
+
 (def ^{:private true} whitelist (atom {}))
 
 (defn- endpoint-key [scope schema-name endpoint-name]
@@ -39,6 +43,8 @@
             {}
             field-map)))
 
+;; registered widgets and fields will be whitelisted
+
 (defn register-widget [widget-name field-map]
   (do (register-endpoint "widget" (rest-widget-fn field-map) widget-name)
       (doseq [[key field-fn] field-map]
@@ -50,3 +56,5 @@
 (defmacro def-rest-widget
   [name body]
   `(register-widget (str (quote ~name)) ~body))
+
+;; helpers for managing whitelisted endpoints

--- a/src/datomic_rest_api/rest/core.clj
+++ b/src/datomic_rest_api/rest/core.clj
@@ -13,8 +13,36 @@
     (let [wbid-field (str class "/id")]
       (widget-fn (d/entity db [(keyword wbid-field) id])))))
 
+(def whitelist (atom {}))
+
+(defn register-endpoint [scope schema endpoint-fn endpoint-label]
+  (let [endpoint-key (-> (str/join "." [scope schema endpoint-label])
+                         (str/replace #"-" "_"))]
+    (swap! whitelist assoc endpoint-key endpoint-fn)))
+
+(defn rest-widget-fn [field-map]
+  (fn [binding]
+    (reduce (fn [result-map [key field-fn]]
+              (assoc result-map key (field-fn binding)))
+            {}
+            field-map)))
+
+(defn register-widget [widget-name field-map]
+  (let [schema-name (-> (str *ns*)
+                        (str/split #"\.")
+                        (last))]
+    (do (register-endpoint "widget" schema-name (rest-widget-fn field-map) widget-name)
+        (doseq [[key field-fn] field-map]
+          (register-endpoint "field" schema-name field-fn (name key)))
+        (println (keys @whitelist)))))
+
 (defmacro def-rest-widget
-  "def-rest-widget is synonymous to defn"
-  [name [binding] & body]
-  `(defn ~name [~binding]
-     (do ~@body)))
+  [name body]
+  `(register-widget (str (quote ~name)) ~body))
+
+
+;; (defmacro def-rest-widget
+;;   "def-rest-widget is synonymous to defn"
+;;   [name [binding] & body]
+;;   `(defn ~name [~binding]
+;;      (do ~@body)))

--- a/src/datomic_rest_api/rest/widgets/gene.clj
+++ b/src/datomic_rest_api/rest/widgets/gene.clj
@@ -1,5 +1,5 @@
 (ns datomic-rest-api.rest.widgets.gene
-  (:require [datomic-rest-api.rest.core :refer [def-rest-widget]]
+  (:require [datomic-rest-api.rest.core :refer [def-rest-widget register-independent-field]]
             [datomic-rest-api.rest.fields.gene :as gene-fields]))
 
 (def-rest-widget overview
@@ -108,3 +108,8 @@
 (def-rest-widget external-links
   {:name  gene-fields/name-field
    :xrefs gene-fields/xrefs})
+
+
+(register-independent-field "fpkm_expression_summary_ls" gene-fields/fpkm-expression-summary-ls)
+(register-independent-field "alleles-other" gene-fields/alleles-other)
+(register-independent-field "polymorphisms" gene-fields/polymorphisms)

--- a/src/datomic_rest_api/rest/widgets/gene.clj
+++ b/src/datomic_rest_api/rest/widgets/gene.clj
@@ -111,5 +111,5 @@
 
 
 (register-independent-field "fpkm_expression_summary_ls" gene-fields/fpkm-expression-summary-ls)
-(register-independent-field "alleles-other" gene-fields/alleles-other)
+(register-independent-field "alleles_other" gene-fields/alleles-other)
 (register-independent-field "polymorphisms" gene-fields/polymorphisms)

--- a/src/datomic_rest_api/rest/widgets/gene.clj
+++ b/src/datomic_rest_api/rest/widgets/gene.clj
@@ -46,18 +46,9 @@
 
 (def-rest-widget mapping-data [gene]
   {:name      (gene-fields/name-field gene)
-
-   :two_pt_data
-   {:data (seq (gene-fields/gene-mapping-twopt gene))
-    :description "Two point mapping data for this gene"}
-
-   :pos_neg_data
-   {:data (seq (gene-fields/gene-mapping-posneg gene))
-    :description "Positive/Negative mapping data for this gene"}
-
-   :multi_pt_data
-   {:data (seq (gene-fields/gene-mapping-multipt gene))
-    :description "Multi point mapping data for this gene"}})
+   :two_pt_data (gene-fields/gene-mapping-twopt gene)
+   :pos_neg_data (gene-fields/gene-mapping-posneg gene)
+   :multi_pt_data (gene-fields/gene-mapping-multipt gene)})
 
 ;; (def-rest-widget human-diseases [gene]
 ;;   {:name                    (gene-fields/name-field gene)

--- a/src/datomic_rest_api/rest/widgets/gene.clj
+++ b/src/datomic_rest_api/rest/widgets/gene.clj
@@ -2,109 +2,109 @@
   (:require [datomic-rest-api.rest.core :refer [def-rest-widget]]
             [datomic-rest-api.rest.fields.gene :as gene-fields]))
 
-(def-rest-widget overview [gene]
-  {:name                     (gene-fields/name-field gene)
-   :version                  (gene-fields/gene-version gene)
-   :classification           (gene-fields/gene-classification gene)
-   :also_refers_to           (gene-fields/also-refers-to gene)
-   :merged_into              (gene-fields/merged-into gene)
-   :gene_class               (gene-fields/gene-class gene)
-   :concise_description      (gene-fields/concise-description gene)
-   :remarks                  (gene-fields/curatorial-remarks gene)
-   :operon                   (gene-fields/gene-operon gene)
-   :gene_cluster             (gene-fields/gene-cluster gene)
-   :other_names              (gene-fields/gene-other-names gene)
-   :taxonomy                 (gene-fields/gene-taxonomy gene)
-   :status                   (gene-fields/gene-status gene)
-   :legacy_information       (gene-fields/legacy-info gene)
-   :named_by                 (gene-fields/named-by gene)
-   :parent_sequence          (gene-fields/parent-sequence gene)
-   :clone                    (gene-fields/parent-clone gene)
-   :cloned_by                (gene-fields/cloned-by gene)
-   :transposon               (gene-fields/transposon gene)
-   :sequence_name            (gene-fields/sequence-name gene)
-   :locus_name               (gene-fields/locus-name gene)
-   :human_disease_relevance  (gene-fields/disease-relevance gene)
-   :structured_description   (gene-fields/structured-description gene)})
+(def-rest-widget overview
+  {:name                     gene-fields/name-field
+   :version                  gene-fields/gene-version
+   :classification           gene-fields/gene-classification
+   :also_refers_to           gene-fields/also-refers-to
+   :merged_into              gene-fields/merged-into
+   :gene_class               gene-fields/gene-class
+   :concise_description      gene-fields/concise-description
+   :remarks                  gene-fields/curatorial-remarks
+   :operon                   gene-fields/gene-operon
+   :gene_cluster             gene-fields/gene-cluster
+   :other_names              gene-fields/gene-other-names
+   :taxonomy                 gene-fields/gene-taxonomy
+   :status                   gene-fields/gene-status
+   :legacy_information       gene-fields/legacy-info
+   :named_by                 gene-fields/named-by
+   :parent_sequence          gene-fields/parent-sequence
+   :clone                    gene-fields/parent-clone
+   :cloned_by                gene-fields/cloned-by
+   :transposon               gene-fields/transposon
+   :sequence_name            gene-fields/sequence-name
+   :locus_name               gene-fields/locus-name
+   :human_disease_relevance  gene-fields/disease-relevance
+   :structured_description   gene-fields/structured-description})
 
-(def-rest-widget phenotype [gene]
-  {:name                     (gene-fields/name-field gene)
-   :drives_overexpression    (gene-fields/drives-overexpression gene)
-   :phenotype                (gene-fields/phenotype-field gene)
-   :phenotype_not_observed   (gene-fields/phenotype-not-observed-field gene)
-   :phenotype_by_interaction (gene-fields/phenotype-by-interaction gene)})
+(def-rest-widget phenotype
+  {:name                     gene-fields/name-field
+   :drives_overexpression    gene-fields/drives-overexpression
+   :phenotype                gene-fields/phenotype-field
+   :phenotype_not_observed   gene-fields/phenotype-not-observed-field
+   :phenotype_by_interaction gene-fields/phenotype-by-interaction})
 
-(def-rest-widget genetics [gene]
-  {:reference_allele (gene-fields/reference-allele gene)
-   :rearrangements   (gene-fields/rearrangements gene)
-   :strains          (gene-fields/strains gene)
-   :alleles          (gene-fields/alleles gene)
-   :alleles_count    (gene-fields/alleles-count gene)
-;;   :alleles_other    (gene-fields/alleles-other gene)  ;; can be requested through /rest/field/
-;;   :polymorphisms    (gene-fields/polymorphisms gene)  ;; can be requested through /rest/field/
-   :name             (gene-fields/name-field gene)})
+(def-rest-widget genetics
+  {:reference_allele gene-fields/reference-allele
+   :rearrangements   gene-fields/rearrangements
+   :strains          gene-fields/strains
+   :alleles          gene-fields/alleles
+   :alleles_count    gene-fields/alleles-count
+;;   :alleles_other    gene-fields/alleles-other  ;; can be requested through /rest/field/
+;;   :polymorphisms    gene-fields/polymorphisms  ;; can be requested through /rest/field/
+   :name             gene-fields/name-field})
 
-(def-rest-widget mapping-data [gene]
-  {:name      (gene-fields/name-field gene)
-   :two_pt_data (gene-fields/gene-mapping-twopt gene)
-   :pos_neg_data (gene-fields/gene-mapping-posneg gene)
-   :multi_pt_data (gene-fields/gene-mapping-multipt gene)})
+(def-rest-widget mapping-data
+  {:name      gene-fields/name-field
+   :two_pt_data gene-fields/gene-mapping-twopt
+   :pos_neg_data gene-fields/gene-mapping-posneg
+   :multi_pt_data gene-fields/gene-mapping-multipt})
 
-;; (def-rest-widget human-diseases [gene]
-;;   {:name                    (gene-fields/name-field gene)
-;;    :human_disease_relevance (gene-fields/disease-relevance gene)
-;;    :human_diseases          (gene-fields/disease-models gene)})
+;; (def-rest-widget human-diseases
+;;   {:name                    gene-fields/name-field
+;;    :human_disease_relevance gene-fields/disease-relevance
+;;    :human_diseases          gene-fields/disease-models})
 
-;; (def-rest-widget reagents [gene]
-;;   {:name               (gene-fields/name-field gene)
-;;    :transgenes         (gene-fields/transgenes gene)
-;;    :transgene_products (gene-fields/transgene-products gene)
-;;    :microarray_probes  (gene-fields/microarray-probes gene)
-;;    :matching_cdnas     (gene-fields/matching-cdnas gene)
-;;    :antibodies         (gene-fields/antibodies gene)
-;;    :orfeome_primers    (gene-fields/orfeome-primers gene)
-;;    :primer_pairs       (gene-fields/primer-pairs gene)
-;;    :sage_tags          (gene-fields/sage-tags gene)})
+;; (def-rest-widget reagents
+;;   {:name               gene-fields/name-field
+;;    :transgenes         gene-fields/transgenes
+;;    :transgene_products gene-fields/transgene-products
+;;    :microarray_probes  gene-fields/microarray-probes
+;;    :matching_cdnas     gene-fields/matching-cdnas
+;;    :antibodies         gene-fields/antibodies
+;;    :orfeome_primers    gene-fields/orfeome-primers
+;;    :primer_pairs       gene-fields/primer-pairs
+;;    :sage_tags          gene-fields/sage-tags})
 
-;; (def-rest-widget gene-ontology [gene]
-;;   {:name                   (gene-fields/name-field gene)
-;;    :gene_ontology_summary  (gene-fields/gene-ontology-summary gene)
-;;    :gene_ontology          (gene-fields/gene-ontology-full gene)})
+;; (def-rest-widget gene-ontology
+;;   {:name                   gene-fields/name-field
+;;    :gene_ontology_summary  gene-fields/gene-ontology-summary
+;;    :gene_ontology          gene-fields/gene-ontology-full})
 
-;; (def-rest-widget expression [gene]
-;;   {:name                (gene-fields/name-field gene)
-;;    :anatomy_terms       (gene-fields/anatomy-terms gene)
-;;    :expression_patterns (gene-fields/expression-patterns gene)
-;;    :expression_cluster  (gene-fields/expression-clusters gene)
-;;    :expression_profiling_graphs (gene-fields/expression-profiling-graphs gene)
-;;    :anatomic_expression_patterns (gene-fields/anatomic-expression-patterns gene)
-;;    :microarray_topology_map_position (gene-fields/microarray-topology-map-position gene)
-;;    :fourd_expression_movies (gene-fields/fourd-expression-movies gene)
-;;    :anatomy_function (gene-fields/anatomy-function gene)})
+;; (def-rest-widget expression
+;;   {:name                gene-fields/name-field
+;;    :anatomy_terms       gene-fields/anatomy-terms
+;;    :expression_patterns gene-fields/expression-patterns
+;;    :expression_cluster  gene-fields/expression-clusters
+;;    :expression_profiling_graphs gene-fields/expression-profiling-graphs
+;;    :anatomic_expression_patterns gene-fields/anatomic-expression-patterns
+;;    :microarray_topology_map_position gene-fields/microarray-topology-map-position
+;;    :fourd_expression_movies gene-fields/fourd-expression-movies
+;;    :anatomy_function gene-fields/anatomy-function})
 
-;; (def-rest-widget homology [gene]
-;;   {:name                (gene-fields/name-field gene)
+;; (def-rest-widget homology
+;;   {:name                gene-fields/name-field
 ;;    :nematode_orthologs  (gene-fields/homology-orthologs gene nematode-species)
 ;;    :human_orthologs     (gene-fields/homology-orthologs gene ["Homo sapiens"])
 ;;    :other_orthologs     (gene-fields/homology-orthologs-not gene (conj nematode-species "Homo sapiens"))
-;;    :paralogs            (gene-fields/homology-paralogs gene)
-;;    :best_blastp_matches (gene-fields/best-blastp-matches gene)
-;;    :protein_domains     (gene-fields/protein-domains gene)})
+;;    :paralogs            gene-fields/homology-paralogs
+;;    :best_blastp_matches gene-fields/best-blastp-matches
+;;    :protein_domains     gene-fields/protein-domains})
 
-(def-rest-widget history [gene]
-  {:name      (gene-fields/name-field gene)
-   :history   (gene-fields/history-events gene)
-   :old_annot (gene-fields/old-annot gene)})
+(def-rest-widget history
+  {:name      gene-fields/name-field
+   :history   gene-fields/history-events
+   :old_annot gene-fields/old-annot})
 
-;; (def-rest-widget sequences [gene]
-;;   {:name         (gene-fields/name-field gene)
-;;    :gene_models  (gene-fields/gene-models gene)})
+;; (def-rest-widget sequences
+;;   {:name         gene-fields/name-field
+;;    :gene_models  gene-fields/gene-models})
 
-;; (def-rest-widget features [gene]
-;;   {:feature_image (gene-fields/feature-image gene)
-;;    :name       (gene-fields/name-field gene)
-;;    :features   (gene-fields/associated-features gene)})
+;; (def-rest-widget features
+;;   {:feature_image gene-fields/feature-image
+;;    :name       gene-fields/name-field
+;;    :features   gene-fields/associated-features})
 
-(def-rest-widget external-links [gene]
-  {:name  (gene-fields/name-field gene)
-   :xrefs (gene-fields/xrefs gene)})
+(def-rest-widget external-links
+  {:name  gene-fields/name-field
+   :xrefs gene-fields/xrefs})


### PR DESCRIPTION
Hi,

**The goal of this PR is to avoid having to hard code the index page and whitelist with widget and field information.** Instead, they are populated when calling `def-rest-widget`, `register-widget`, and `register-independent-field`.

Highlight of changes:
- the signature of the `def-rest-widget` is changed to take a map of field name to the corresponding field function. (Rather than an arbitrary function body). The reason for this change is to accurately resolve calls to a field level endpoint. If you prefer the original signature, we can discuss about this.
- `def-rest-widget` macro provide syntactic sugar for `register-widget` function. I'm not sure if this is necessary. 
- minor change to mapping_data functions to behave like standard field functions (return {:data :description} etc)
