### PR TITLE
reuse fpkm for transcript

### DIFF
--- a/src/datomic_rest_api/get_handler.clj
+++ b/src/datomic_rest_api/get_handler.clj
@@ -14,7 +14,10 @@
             [mount.core :as mount]
             [datomic-rest-api.utils.db :refer (datomic-conn)]
             [datomic-rest-api.rest.core :refer (field-adaptor widget-adaptor resolve-endpoint endpoint-urls)]
-            [datomic-rest-api.rest.widgets.gene :as gene]))
+
+            ;; widget definition file are required for their "side-effect", ie. register with whitelist
+            [datomic-rest-api.rest.widgets.gene]
+            [datomic-rest-api.rest.widgets.transcript]))
 
 
 (declare handle-field-get)

--- a/src/datomic_rest_api/rest/fields/gene.clj
+++ b/src/datomic_rest_api/rest/fields/gene.clj
@@ -3,6 +3,7 @@
             [pseudoace.binning :refer (reg2bins xbin bins)]
             [datomic-rest-api.rest.helpers.date :as date-helper]
             [datomic-rest-api.rest.helpers.object :as rest-api-obj :refer (humanize-ident get-evidence author-list pack-obj)]
+            [datomic-rest-api.rest.helpers.expression :as expression]
             [datomic.api :as d :refer (db q touch entity)]
             [clojure.string :as str]
             [pseudoace.utils :refer [vmap vmap-if vassoc cond-let those conjv]]
@@ -1702,67 +1703,8 @@
   {:data nil ;; this resquires segment data and can be found in the file: lib/WormBase/API/Role/Expression.pm
    :description "microarray topography map"})
 
-(defn- control-analysis? [analysis]
-  (if-let [matched (re-matches #".+control_(mean|median)"
-                               (:analysis/id analysis))]
-    (let [[_ stat-type] matched]
-      stat-type)))
-
 (defn fpkm-expression-summary-ls [gene]
-  (let [db (d/entity-db gene)
-        result-tuples (->> (q '[:find ?analysis ?fpkm ?stage
-                                :in $ ?gene
-                                :where [?gene :gene/rnaseq ?rnaseq]
-                                       [?rnaseq :gene.rnaseq/stage ?stage]
-                                       [?rnaseq :gene.rnaseq/fpkm ?fpkm]
-                                       [?rnaseq :evidence/from-analysis ?analysis]]
-                              db (:db/id gene))
-                           (map (fn [[analysis-id fpkm stage-id]]
-                                  (let [analysis (entity db analysis-id)
-                                        stage (entity db stage-id)]
-                                    [analysis fpkm stage]))))
-        results (->> result-tuples
-                     (filter (fn [[analysis]] (not (control-analysis? analysis))))
-                     (map (fn [[analysis fpkm stage]]
-                            {:value fpkm
-                             :life_stage (pack-obj stage)
-                             :project_info (-> (first (:analysis/project analysis))
-                                               (pack-obj)
-                                               (into {:experiment (-> (:analysis/id analysis)
-                                                                      (str/split #"\.")
-                                                                      (last))}))
-                             :label (pack-obj analysis)})))
-        controls (->> result-tuples
-                      (filter (fn [[analysis]] (control-analysis? analysis)))
-                      (map (fn [[analysis fpkm stage]]
-                             (let [stat-type (->> (control-analysis? analysis)
-                                                  (str "control ")
-                                                  (keyword))]
-                               {stat-type {:text fpkm
-                                           :evidence {:comment (:analysis/description analysis)}}
-                                :life_stage (if (re-find #"total_over_all_stages" (:analysis/id analysis))
-                                              (rest-api-obj/pack-text "total_over_all_stages")  ;refer to WormBase/website#4540
-                                              (pack-obj stage))})))
-                      (group-by (fn [control]
-                                  (:id (:life_stage control))))
-                      (map (fn [[_ controls]]
-                             (apply merge controls))))
-        studies (->> result-tuples
-                     (filter (fn [[analysis]] (not (control-analysis? analysis))))
-                     (map (fn [[analysis]]
-                            (first (:analysis/project analysis))))
-                     (set)
-                     (map (fn [project]
-                            {(keyword (:analysis/id project)) {:title (first (:analysis/title project))
-                                                               :tag (pack-obj project)
-                                                               :indep_variable (map humanize-ident (:analysis/independent-variable project))
-                                                               :description (:analysis/description project)}}))
-                     (apply merge))]
-    {:data (if (empty? results) nil
-               {:controls controls
-                :by_study studies
-                :table {:fpkm {:data results}}})
-     :description "Fragments Per Kilobase of transcript per Million mapped reads (FPKM) expression data"}))
+  (expression/fpkm-expression-summary-ls gene))
 
 
 

--- a/src/datomic_rest_api/rest/fields/transcript.clj
+++ b/src/datomic_rest_api/rest/fields/transcript.clj
@@ -1,0 +1,20 @@
+(ns datomic-rest-api.rest.fields.transcript
+  (:require [datomic-rest-api.rest.helpers.object :as rest-api-obj :refer (humanize-ident get-evidence author-list pack-obj)]
+            [datomic-rest-api.rest.helpers.expression :as expression]
+            [datomic.api :as d :refer (db q touch entity)]
+            [clojure.string :as str]
+            [pseudoace.utils :refer [vmap vmap-if vassoc cond-let those conjv]]))
+
+;;
+;; Expression widget
+;;
+(defn fpkm-expression-summary-ls [transcript]
+  (let [db (d/entity-db transcript)]
+    (->>
+     (q '[:find ?gene .
+          :in $ ?transcript
+          :where [?gene :gene/corresponding-transcript ?th]
+                 [?th :gene.corresponding-transcript/transcript ?transcript]]
+        db (:db/id transcript))
+     (d/entity db)
+     (expression/fpkm-expression-summary-ls))))

--- a/src/datomic_rest_api/rest/helpers/expression.clj
+++ b/src/datomic_rest_api/rest/helpers/expression.clj
@@ -1,0 +1,68 @@
+(ns datomic-rest-api.rest.helpers.expression
+  (:use pseudoace.utils)
+  (:import java.text.SimpleDateFormat)
+  (:require [datomic.api :as d :refer (q)]
+            [clojure.string :as str]
+            [datomic-rest-api.rest.helpers.object :as rest-api-obj :refer (humanize-ident get-evidence pack-obj)]))
+
+(defn- control-analysis? [analysis]
+  (if-let [matched (re-matches #".+control_(mean|median)"
+                               (:analysis/id analysis))]
+    (let [[_ stat-type] matched]
+      stat-type)))
+
+(defn fpkm-expression-summary-ls [gene]
+  (let [db (d/entity-db gene)
+        result-tuples (->> (q '[:find ?analysis ?fpkm ?stage
+                                :in $ ?gene
+                                :where [?gene :gene/rnaseq ?rnaseq]
+                                       [?rnaseq :gene.rnaseq/stage ?stage]
+                                       [?rnaseq :gene.rnaseq/fpkm ?fpkm]
+                                       [?rnaseq :evidence/from-analysis ?analysis]]
+                              db (:db/id gene))
+                           (map (fn [[analysis-id fpkm stage-id]]
+                                  (let [analysis (d/entity db analysis-id)
+                                        stage (d/entity db stage-id)]
+                                    [analysis fpkm stage]))))
+        results (->> result-tuples
+                     (filter (fn [[analysis]] (not (control-analysis? analysis))))
+                     (map (fn [[analysis fpkm stage]]
+                            {:value fpkm
+                             :life_stage (pack-obj stage)
+                             :project_info (-> (first (:analysis/project analysis))
+                                               (pack-obj)
+                                               (into {:experiment (-> (:analysis/id analysis)
+                                                                      (str/split #"\.")
+                                                                      (last))}))
+                             :label (pack-obj analysis)})))
+        controls (->> result-tuples
+                      (filter (fn [[analysis]] (control-analysis? analysis)))
+                      (map (fn [[analysis fpkm stage]]
+                             (let [stat-type (->> (control-analysis? analysis)
+                                                  (str "control ")
+                                                  (keyword))]
+                               {stat-type {:text fpkm
+                                           :evidence {:comment (:analysis/description analysis)}}
+                                :life_stage (if (re-find #"total_over_all_stages" (:analysis/id analysis))
+                                              (rest-api-obj/pack-text "total_over_all_stages")  ;refer to WormBase/website#4540
+                                              (pack-obj stage))})))
+                      (group-by (fn [control]
+                                  (:id (:life_stage control))))
+                      (map (fn [[_ controls]]
+                             (apply merge controls))))
+        studies (->> result-tuples
+                     (filter (fn [[analysis]] (not (control-analysis? analysis))))
+                     (map (fn [[analysis]]
+                            (first (:analysis/project analysis))))
+                     (set)
+                     (map (fn [project]
+                            {(keyword (:analysis/id project)) {:title (first (:analysis/title project))
+                                                               :tag (pack-obj project)
+                                                               :indep_variable (map humanize-ident (:analysis/independent-variable project))
+                                                               :description (:analysis/description project)}}))
+                     (apply merge))]
+    {:data (if (empty? results) nil
+               {:controls controls
+                :by_study studies
+                :table {:fpkm {:data results}}})
+     :description "Fragments Per Kilobase of transcript per Million mapped reads (FPKM) expression data"}))

--- a/src/datomic_rest_api/rest/widgets/transcript.clj
+++ b/src/datomic_rest_api/rest/widgets/transcript.clj
@@ -1,0 +1,5 @@
+(ns datomic-rest-api.rest.widgets.transcript
+  (:require [datomic-rest-api.rest.core :refer [def-rest-widget register-independent-field]]
+            [datomic-rest-api.rest.fields.transcript :as transcript-fields]))
+
+(register-independent-field "fpkm_expression_summary_ls" transcript-fields/fpkm-expression-summary-ls)


### PR DESCRIPTION
The fpkm field on Transcript page should be identical to the one on its corresponding gene page (according to [Gary W's comment here](https://github.com/WormBase/website/issues/5301#issuecomment-265432749). 

This PR extracts the fpkm field function to be used by both the gene and the transcript. The amount of changes should be minor. Thanks for reviewing :)