### PR TITLE
remove problematic ahead-of-time compilation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -29,8 +29,9 @@
   :plugins [[lein-cljsbuild "1.1.3"]
             [lein-pprint "1.1.1"]
             [lein-ring "0.9.7"]]
-  :main datomic-rest-api.get-handler
+  :main ^:skip-aot datomic-rest-api.get-handler
   :aot [datomic-rest-api.get-handler]
+  :uberjar {:aot :all}
   :ring {:handler datomic-rest-api.get-handler/app
          :host "0.0.0.0"
          :init datomic-rest-api.get-handler/init}

--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,6 @@
             [lein-pprint "1.1.1"]
             [lein-ring "0.9.7"]]
   :main datomic-rest-api.get-handler
-  :aot [datomic-rest-api.get-handler]
   :ring {:handler datomic-rest-api.get-handler/app
          :host "0.0.0.0"
          :init datomic-rest-api.get-handler/init}


### PR DESCRIPTION
Hi @a8wright @mgrbyte @azurebrd  I think avoiding Ahead-of-time compilation might be a fix for the mount problem #44, along with the problem that the server doesn't always update when `rest/fields/gene.clj` is modified.

**Please run `lein clean` before starting the server for the _first time_ with this change.** This hopefully remove the product of previous compilation. It seems to work for me consistently. Please let me know whether this solution works for you guys. Thanks!

I don't have a full explanation for the fix. I don't understand the details about lein's compilation process myself. But based on the two issues #44 and the reloading problem, it appears that we get different compilation results based on timestamps of the source file. So the experiment has been to simplify compilation settings in the `project.clj` file, in particular avoid things that might cause a "stateful" compilation.
