### PR TITLE
Fixed all urls that were throwing a 500 error

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -59,7 +59,7 @@
                              [com.jakemccrary/lein-test-refresh "0.17.0"]]
                    :eastwood {:add-linters [:unused-namespaces]
                               :exclude-namespaces [user]}
-		   :ring {:nrepl {:start? true :port 8131}}}
+		   :ring {:nrepl {:start? true}}}
 
              :datomic-free
              {:dependencies [[com.datomic/datomic-free "0.9.5554"

--- a/src/datomic_rest_api/db/sequence.clj
+++ b/src/datomic_rest_api/db/sequence.clj
@@ -15,14 +15,14 @@
        json/read))
 
 (defn get-default-sequence-database [g-species]
-  (if (some? (species-assemblies g-species))
-    (let [defaults (for [assembly ((species-assemblies g-species) "assemblies") :when (= (assembly "is_canonical") true)]
+  (if-let [assemblies (species-assemblies g-species)]
+    (let [defaults (for [assembly (assemblies "assemblies") :when (= (assembly "is_canonical") true)]
                      (str/join
                        "_"
                        [g-species
                         (assembly "bioproject")
                         (database-version)]))]
-      (if (some? defaults)
+      (if (seq defaults)
         (first defaults)))))
 
 (def sequence-dbs

--- a/src/datomic_rest_api/db/sequence.clj
+++ b/src/datomic_rest_api/db/sequence.clj
@@ -15,13 +15,15 @@
        json/read))
 
 (defn get-default-sequence-database [g-species]
-  (first
-    (for [assembly ((species-assemblies g-species) "assemblies") :when (= (assembly "is_canonical") true)]
-      (str/join
-        "_"
-        [g-species
-         (assembly "bioproject")
-         (database-version)]))))
+  (if (some? (species-assemblies g-species))
+    (let [defaults (for [assembly ((species-assemblies g-species) "assemblies") :when (= (assembly "is_canonical") true)]
+                     (str/join
+                       "_"
+                       [g-species
+                        (assembly "bioproject")
+                        (database-version)]))]
+      (if (some? defaults)
+        (first defaults)))))
 
 (def sequence-dbs
   (into

--- a/src/datomic_rest_api/rest/fields/gene.clj
+++ b/src/datomic_rest_api/rest/fields/gene.clj
@@ -908,7 +908,7 @@
                 (map
                  (fn [tp]
                    {:mapper     (pack-obj "author" (first (:two-point-data/mapper tp)))
-                    :date       (if (some? (:two-point-data/date tp))
+                    :date       (if (:two-point-data/date tp)
                                   (date-helper/format-date (:two-point-data/date tp)))
                     :raw_data   (:two-point-data/results tp)
                     :genotype   (:two-point-data/genotype tp)
@@ -955,15 +955,15 @@
                                                 pn))]
                                     (map (juxt :label identity))
                                     (into {}))
-                         result (if (some? (:pos-neg-data/results pn))
+                         result (if (:pos-neg-data/results pn)
                                   (str/split (:pos-neg-data/results pn) #"\s+"))]
-                     {:mapper (if (some? (:pos-neg-data/mapper pn))
+                     {:mapper (if (seq (:pos-neg-data/mapper pn))
                                 (pack-obj "author" (first (:pos-neg-data/mapper pn))))
                       :comment (let [comment (str/join "<br>" (map :pos-neg-data.remark/text (:pos-neg-data/remark pn)))]
                                  (if (empty? comment) "" comment ))
-                      :date (if (some? (:pos-neg-data/date pn))
+                      :date (if (:pos-neg-data/date pn)
                               (date-helper/format-date (:pos-neg-data/date pn)))
-                      :result (if (some? result)
+                      :result (if (seq result)
                                 (map #(or (items (str/replace % #"\." ""))
                                         (str % " "))
                                    result))})))
@@ -1176,10 +1176,8 @@
         :Date_last_updated
         (if-let [d (:go-annotation/date-last-updated anno)]
           [{:class "text"
-            :id (if (some? d)
-                  (date-helper/format-date3 (str d)))
-            :label (if (some? d)
-                     (date-helper/format-date3 (str d)))}])
+            :id (date-helper/format-date3 (str d))
+            :label (date-helper/format-date3 (str d))}])
 
         :Contributed_by
         [(pack-obj "analysis"
@@ -1402,7 +1400,7 @@
        (let [result {:version (:gene.version-change/version h)
                      :curator (pack-obj "person" (:gene.version-change/person h))
                      :remark  nil
-                     :date    (if (some? (:gene.version-change/date h))
+                     :date    (if (:gene.version-change/date h)
                                 (date-helper/format-date (:gene.version-change/date h)))
                      :type    "Version_change"
                      :gene    nil
@@ -1650,7 +1648,7 @@
 (defn- get-segments [gene]
   (let [g-species (parse-species-name (:species/id (:gene/species gene)))
         sequence-database (seqdb/get-default-sequence-database g-species)]
-    (if (some? sequence-database)
+    (if sequence-database
       (sequence-features sequence-database (:gene/id gene)))))
 
 (defn- longest-segment [segments]
@@ -1659,7 +1657,7 @@
 
 (defn- get-segment [gene]
   (let [segments (get-segments gene)]
-     (if (some? segments)
+     (if (seq segments)
        (longest-segment segments))))
 
 (defn- segment-to-position [gene segment gbrowse]

--- a/src/datomic_rest_api/rest/helpers/object.clj
+++ b/src/datomic_rest_api/rest/helpers/object.clj
@@ -77,7 +77,7 @@
      (str (author-lastname (first authors)) " et al."))))
 
 (defmethod obj-label "paper" [_ paper]
-  (if (some? (:paper/publication-date paper))
+  (if (seq (:paper/publication-date paper))
     (str (author-list paper)
          ", "
          (first (str/split (:paper/publication-date paper)

--- a/src/datomic_rest_api/rest/helpers/object.clj
+++ b/src/datomic_rest_api/rest/helpers/object.clj
@@ -77,10 +77,11 @@
      (str (author-lastname (first authors)) " et al."))))
 
 (defmethod obj-label "paper" [_ paper]
-  (str (author-list paper)
-       ", "
-       (first (str/split (:paper/publication-date paper)
-                         #"-"))))
+  (if (some? (:paper/publication-date paper))
+    (str (author-list paper)
+         ", "
+         (first (str/split (:paper/publication-date paper)
+                           #"-")))))
 
 (defmethod obj-label "feature" [_ feature]
   (or (:feature/public-name feature)


### PR DESCRIPTION
Yesterday I noticed that some URLs with d-t-c WS256 in production are throwing 500 errors. This isn't a big deal as Catalyst will generate the correct URL for the user but would make it so that we can not delete the functionality from the catalyst code. 

Yesterday I wrote a test script that went through every possible Gene widget combination and with these changes have reduced the number of 500 errors to zero. 

I can run this test when ever we add another URL or make significant changes to a URL. 

I tested these changes with eastwood and everything passed as well. 

I intend on having this rolled out before WS257 goes live (by the end of the week). 