### PR TITLE
top-level data-structure of api responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Run following commands and test each step happens correctly.
 ```bash
 export WS_VERSION=WS257
 export TRACE_DB="datomic:ddb://us-east-1/WS257/wormbase"
-lein with-profile +datomic-pro,+ddb ring server-headless 8130
-lein with-profile +datomic-pro,+ddb do eastwood, test
+lein ring server-headless 8130
+lein do eastwood, test
 make docker-build
 make run
 docker ps -a
@@ -40,25 +40,25 @@ export TRACE_DB="datomic:ddb://us-east-1/WS257/wormbase"
 
 ## Starting server in development
 ```bash
-lein with-profile +datomic-pro,+ddb ring server-headless 8130
+lein ring server-headless 8130
 ```
 
 ### Code linting
 Check for code purity, unused namespaces et al.
 ```bash
-lein with-profile +datomic-pro,+ddb eastwood
+lein eastwood
 ```
 
 ### Running unit tests
 
 To run tests that watch for changes in the repo:
 ```bash
-lein with-profile +datomic-pro,+ddb test-refresh
+lein test-refresh
 ```
 
 To run all tests:
 ```bash
-lein with-profile +datomic-pro,+ddb test
+lein test
 ```
 
 ## Deploying to production

--- a/project.clj
+++ b/project.clj
@@ -47,20 +47,7 @@
              "-XX:+UseG1GC" "-XX:MaxGCPauseMillis=50"
              "-Ddatomic.objectCacheMax=2500000000"
              "-Ddatomic.txTimeoutMsec=1000000"]
-  :profiles {:dev {:dependencies [[ring/ring-devel "1.5.1"]]
-                   :source-paths ["dev"]
-                   :env
-                   {:trace-db "datomic:ddb://us-east-1/WS257/wormbase"}
-                   :plugins [[jonase/eastwood "0.2.3"]
-                             [lein-ancient "0.6.8"]
-                             [lein-bikeshed "0.3.0"]
-                             [lein-ns-dep-graph "0.1.0-SNAPSHOT"]
-                             [venantius/yagni "0.1.4"]
-                             [com.jakemccrary/lein-test-refresh "0.17.0"]]
-                   :eastwood {:add-linters [:unused-namespaces]
-                              :exclude-namespaces [user]}
-		   :ring {:nrepl {:start? true}}}
-             :datomic-free
+  :profiles {:datomic-free
              {:dependencies [[com.datomic/datomic-free "0.9.5554"
                               :exclusions [joda-time]]]}
              :datomic-pro
@@ -69,5 +56,20 @@
              :ddb
              {:dependencies
               [[com.amazonaws/aws-java-sdk-dynamodb "1.11.6"
-                :exclusions [joda-time]]]}}
+                :exclusions [joda-time]]]}
+             :dev [:datomic-pro
+                   :ddb
+                   {:dependencies [[ring/ring-devel "1.5.1"]]
+                     :source-paths ["dev"]
+                     :env
+                     {:trace-db "datomic:ddb://us-east-1/WS257/wormbase"}
+                     :plugins [[jonase/eastwood "0.2.3"]
+                               [lein-ancient "0.6.8"]
+                               [lein-bikeshed "0.3.0"]
+                               [lein-ns-dep-graph "0.1.0-SNAPSHOT"]
+                               [venantius/yagni "0.1.4"]
+                               [com.jakemccrary/lein-test-refresh "0.17.0"]]
+                     :eastwood {:add-linters [:unused-namespaces]
+                                :exclude-namespaces [user]}
+                     :ring {:nrepl {:start? true}}}]}
   :repl-options {:init (set! *print-length* 10)})

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,6 @@
    [com.layerware/hugsql "0.4.7"]
    [com.ninjudd/eventual "0.5.5"]
    [com.ninjudd/ring-async "0.3.4"]
-   [compojure "1.5.2"]
    [datomic-schema "1.3.0"]
    [environ "1.1.0"]
    [fogus/ring-edn "0.3.0"]

--- a/src/rest_api/classes/gene.clj
+++ b/src/rest_api/classes/gene.clj
@@ -7,12 +7,12 @@
    [rest-api.classes.gene.widgets.mapping-data :as mapping-data]
    [rest-api.classes.gene.widgets.ontology :as gene-ontology]
    [rest-api.classes.gene.widgets.overview :as overview]
-   [rest-api.classes.gene.widgets.phenotypes :as phenotypes]
+   [rest-api.classes.gene.widgets.phenotype :as phenotype]
    [rest-api.classes.gene.variation :as variation]
    [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:datatype "gene"
+  {:entity-class "gene"
    :widget
    {:external_links external-links/widget
     :feature feature/widget
@@ -21,7 +21,7 @@
     :history history/widget
     :mapping_data mapping-data/widget
     :overview overview/widget
-    :phenotypes phenotypes/widget}
+    :phenotype phenotype/widget}
    :field
    {:alles_other variation/alleles-other
     :polymorphisms variation/polymorphisms}})

--- a/src/rest_api/classes/gene/widgets/phenotype.clj
+++ b/src/rest_api/classes/gene/widgets/phenotype.clj
@@ -1,4 +1,4 @@
-(ns rest-api.classes.gene.widgets.phenotypes
+(ns rest-api.classes.gene.widgets.phenotype
   (:require
    [clojure.string :as str]
    [datomic.api :as d]

--- a/src/rest_api/classes/transcript.clj
+++ b/src/rest_api/classes/transcript.clj
@@ -4,6 +4,6 @@
    [rest-api.classes.gene.expression :as exp]))
 
 (routing/defroutes
-  {:datatype "transcript"
+  {:entity-class "transcript"
    :field
    {:fpkm_expression_summary_ls exp/fpkm-expression-summary-ls}})

--- a/src/rest_api/routing.clj
+++ b/src/rest_api/routing.clj
@@ -1,6 +1,6 @@
 (ns rest-api.routing
   (:require
-   [cheshire.core :as json] ;; TODO: remove, see main.clj
+   [cheshire.core :as json] ;; TODO: use compojure.api's formats instead
    [clojure.string :as str]
    [compojure.api.sweet :as sweet]
    [datomic.api :as d]

--- a/src/rest_api/routing.clj
+++ b/src/rest_api/routing.clj
@@ -1,104 +1,109 @@
 (ns rest-api.routing
-  (:require 
-   [cheshire.core :as json]
+  (:require
+   [cheshire.core :as json] ;; TODO: remove, see main.clj
    [clojure.string :as str]
    [compojure.api.sweet :as sweet]
    [datomic.api :as d]
    [rest-api.db.main :refer [datomic-conn]]
-   [ring.util.response :as ring]
+   [ring.util.request :as ring-in]
+   [ring.util.response :as ring-out]
    [schema.core :as schema]))
 
 (defn- json-response [data]
   (-> data
       (json/generate-string {:pretty true})
-      (ring/response)
-      (ring/content-type "application/json")))
+      (ring-out/response)
+      (ring-out/content-type "application/json")))
 
-(defn- entity-not-found [schema-name id]
-  (-> {:message (format "Entity %s %s does not exist" schema-name id)}
+(defn- entity-not-found [entity-class id]
+  (-> {:message (format "%s entity %s does not exist" entity-class id)}
       (json-response)
-      (ring/status 404)))
+      (ring-out/status 404)))
 
-(defn- wrap-entity-handler [entity-handler]
-  (fn [schema-name id]
+(defn- conform-uri [request]
+  (str/replace-first (:uri request) "/" ""))
+
+(defmulti conform-to-scheme
+  (fn [scheme entity-handler entity request]
+    (keyword scheme)))
+
+(defmethod conform-to-scheme :field
+  [scheme entity-handler entity request]
+  (let [result (entity-handler entity)
+
+        ;; TODO:
+        ;; See /WormBase/datomic-to-catalyst/issues/61
+        ;; uri (conform-uri (:uri request))
+        uri (str/replace (:uri request) "/rest/field" "/species")
+
+        endpoint-name (-> (ring-in/path-info request)
+                          (str/split #"/")
+                          (last))]
+    {endpoint-name result
+     :uri uri}))
+
+(defmethod conform-to-scheme :widget
+  [scheme entity-handlers entity request]
+  (let [result (reduce-kv (fn [m k handler]
+                            (assoc m k (handler entity)))
+                          (empty entity-handlers)
+                          entity-handlers)]
+    {:fields result
+     :uri (conform-uri request)}))
+
+(defn make-request-handler [scheme entity-handler]
+  (fn [request]
     (let [db (d/db datomic-conn)
-          attr (keyword schema-name "id")
+          id (get-in request [:params :id])
+          entity-class (-> (:context request)
+                           (str/split #"/")
+                           (last))
+          attr (keyword entity-class "id")
           lookup-ref [attr id]]
-      (if-let [wb-entity (d/entity db lookup-ref)]
-        (entity-handler wb-entity)))))
-
-(defn- wrap-entity-handlers [route-spec]
-  (fn [binding]
-    (reduce-kv (fn [m k handler]
-                 (assoc m k (handler binding)))
-               (empty route-spec)
-               route-spec)))
-
-(defmulti create-routes
-  (fn [a _ _]
-    (map? a)))
-
-(defmethod create-routes
-  true
-  [route-spec endpoint-name datatype]
-  (let [handler (wrap-entity-handlers route-spec)]
-    (create-routes handler endpoint-name datatype)))
-
-(defmethod create-routes
-  false
-  [entity-handler endpoint-name datatype]
-  (let [ep-name (if (keyword? endpoint-name)
-                  (name endpoint-name)
-                  endpoint-name)
-        uri-parts [nil datatype ":id" ep-name]
-        uri (str/join "/" uri-parts)
-        handler (wrap-entity-handler entity-handler)]
-    (sweet/GET uri [id]
-      :path-params [id :- schema/Str]
-      (if-let [result (handler datatype id)]
-        (-> {:name id
-             :class datatype
-             :url (str/replace uri #":id" id)}
-            (assoc (keyword ep-name) result)
-            (json-response))
-        (entity-not-found datatype id)))))
+      (if-let [entity (d/entity db lookup-ref)]
+        (->> (conform-to-scheme scheme entity-handler entity request)
+             (merge {:class entity-class
+                     :name id})
+             (json-response))
+        (entity-not-found entity-class id)))))
 
 (defprotocol RouteSpecification
-  (create
+  (-create-routes
     [route-spec]
     [route-spec opts]))
 
 (defrecord RouteSpec [datatype widget field]
   RouteSpecification
-  (create [this {:keys [publish-widget-fields?] :as opts}]
+  (-create-routes [this {:keys [publish-widget-fields?] :as opts}]
     (let [fields (:field this)
           field-defs (if publish-widget-fields?
                        (apply merge (cons fields (->> this :widget vals)))
                        fields)
           route-data (assoc this :field field-defs)
-          wb-dt (:datatype route-data)]
+          entity-class (:entity-class route-data)]
       (flatten
        (for [kw [:widget :field]
              :let [scheme (name kw)
                    ep-defs (kw route-data)]]
-         (for [[ep-name ep-map] (sort-by key ep-defs)]
-           (sweet/context (str "/" scheme) []
-             :tags [(str datatype " " scheme "s")]
-             (create-routes ep-map ep-name wb-dt)))))))
-  (create [this]
-    (create this {:publish-widget-fields? true})))
+         (for [[ep-kw entity-handler] (sort-by key ep-defs)
+               :let [ep-name (name ep-kw)]]
+           (sweet/context (str "/" scheme "/" entity-class) []
+             :tags [(str entity-class " " scheme "s")]
+             (sweet/GET (str "/:id/" ep-name) []
+               :path-params [id :- schema/Str]
+               (make-request-handler scheme entity-handler))))))))
 
-(defn routes-from-spec
-  "Creates compojure-api routes from the given route spec `rs`."
-  [xs]
-  (let [rs (if (map? xs)
-             (map->RouteSpec xs)
-             xs)]
-    (create rs)))
+  (-create-routes [this]
+    (-create-routes this {:publish-widget-fields? true})))
 
 (defmacro defroutes
   "Convenience constructor for defining `RouteSpec`s.
    Helps ensure this is defined with a constant name when used."
   [& rs]
   `(def ~(symbol "routes")
-     (routes-from-spec (map->RouteSpec ~@rs))))
+     (if-let [rs# (cond
+                   (map? ~@rs) (map->RouteSpec ~@rs)
+                   (vector? ~@rs) (apply ->RouteSpec ~@rs))]
+       (-create-routes rs#)
+       (throw (IllegalArgumentException.
+               (format "Invalid route spec %s" ~@rs))))))

--- a/test/rest_api/classes/gene_test.clj
+++ b/test/rest_api/classes/gene_test.clj
@@ -2,25 +2,15 @@
   (:require
    [clojure.test :refer :all]
    [datomic.api :as d]
-   [mount.core :as mount]
    [rest-api.classes.gene.variation :as variation]
    [rest-api.classes.gene.widgets.genetics :as genetics]
-   [rest-api.db.main :refer [datomic-conn]]))
-
-;; See https://clojure.github.io/clojure/clojure.test-api.html for details
-
-;; my-test-fixture will be passed a fn that will call all your tests
-;; (e.g. test-using-db).  Here you perform any required setup
-;; (e.g. create-db), then call the passed function f, then perform
-;; any required teardown (e.g. destroy-db).
-(defn my-test-fixture [f]
-  (mount/start)
-  (f)
-  (mount/stop))
+   [rest-api.db.main :refer [datomic-conn]]
+   [rest-api.db-testing :as db-testing]
+   ))
 
 ;; Here we register my-test-fixture to be called once, wrapping ALL tests
 ;; in the namespace
-(use-fixtures :once my-test-fixture)
+(use-fixtures :once db-testing/db-lifecycle)
 
 (defn get-gene [id]
   (d/entity (d/db datomic-conn) [:gene/id id]))

--- a/test/rest_api/db_testing.clj
+++ b/test/rest_api/db_testing.clj
@@ -1,0 +1,14 @@
+(ns rest-api.db-testing
+  (:require
+   [datomic.api :as d]
+   [mount.core :as mount]
+   [rest-api.db.main :refer [datomic-conn]]))
+
+(defn db-lifecycle [f]
+  (mount/start)
+  (f)
+  (mount/stop))
+
+(defn entity [lookup-ref]
+  (d/entity (d/db datomic-conn) lookup-ref))
+

--- a/test/rest_api/test_routing.clj
+++ b/test/rest_api/test_routing.clj
@@ -1,0 +1,67 @@
+(ns rest-api.test-routing
+  (:require
+   [clojure.test :refer :all]
+   [compojure.api.routes :as c-routes]
+   [compojure.api.sweet :as sweet]
+   [rest-api.db-testing :as db-testing]
+   [rest-api.routing :as routing]))
+
+(use-fixtures :once db-testing/db-lifecycle)
+
+(deftest test-conform-to-scheme
+  (testing "Is structure correct for catalyst for widget scheme?"
+    (let [req {:uri "/rest/widget/gene/WBGene0101010101/overview"}
+          entity {}
+          [res-x, res-y] [{:data {:x "X"} :description "X desc"}
+                          {:data {:y "Y"} :description "Y desc"}]
+          handler-x (fn [e] res-x)
+          handler-y (fn [e] res-y)
+          entity-handler {:x handler-x :y handler-y}
+          expected {:fields {:x res-x :y res-y}
+                    :uri "rest/widget/gene/WBGene0101010101/overview"}
+          result (routing/conform-to-scheme :widget
+                                            entity-handler
+                                            entity
+                                            req)]
+      (is (= result expected))))
+  (testing "Is structure correct for catalyst for field scheme?"
+    (let [req {:uri "/rest/field/gene/WBGene0101010101/f1"}
+          entity {}
+          result {:data {:x "X"} :description "D"}
+          entity-handler (fn [e] result)
+          expected {"f1" (entity-handler entity)
+                    ;; TODO: dubious
+                    ;; should probably be /rest/field/ rather than
+                    ;; /species
+                    ;; See /WormBase/datomic-to-catalyst/issues/61
+                    :uri "/species/gene/WBGene0101010101/f1"}
+          result (routing/conform-to-scheme :field
+                                            entity-handler
+                                            entity
+                                            req)]
+      (is (= result expected)))))
+
+
+;; setup for test-defroutes
+(let [dummy-handler (fn [_] {})
+      mk-route-spec (fn [keys]
+                      (into {} (for [k keys]
+                                 [k dummy-handler])))
+      widget {:x (mk-route-spec [:a :b :c :d])
+              :y (mk-route-spec [:e :f :g])}
+      fields {:z (mk-route-spec [:h :i])}]
+  (routing/defroutes {:datatype "testing"
+                      :widget widget
+                      :field fields})
+(deftest test-defroutes
+  (testing "Defining routes via `defroutes` macro."
+    ;; Expected counts:
+    ;; 1 (widget) +
+    ;; count of fields in widget +
+    ;; count of independent fields.
+    ;; symbol `routes` is defn'd by defroutes
+    (let [sweet-routes (c-routes/get-routes
+                        (sweet/context "/" []
+                          (apply sweet/routes routes)))]
+      (is (= (count sweet-routes) 10)))
+    (is (every? #(satisfies? c-routes/Routing %) routes)))))


### PR DESCRIPTION
This ~(tentatively)~ fixes #61.

~Please do not merge until we resolve the issue in the comment about `/species` vs `/rest/field` in the `uri` field of field responses.~
