### PR TITLE
Reduce required env vars to just the one for datomic URI.

### DIFF
--- a/.ebextensions/.config
+++ b/.ebextensions/.config
@@ -1,7 +1,5 @@
 option_settings:
-  - option_name: TRACE_DB
+  - option_name: WB_DB_URI
     value: datomic:ddb://us-east-1/WS257/wormbase
-  - option_name: WS_VERSION
-    value: WS257
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 NAME := wormbase/datomic-to-catalyst
 VERSION ?= $(shell git describe --abbrev=0 --tags)
-WS_VERSION := WS257
 LOWER_WS_VERSION = `echo $(WS_VERSION) | tr A-Z a-z`
 EBX_CONFIG := .ebextensions/.config
 DB_URI ?= $(shell sed -rn 's|value:(.*)|\1|p' \
@@ -66,7 +65,7 @@ eb-create: $(call print-help,eb-create,\
 eb-setenv: $(call print-help,eb-env,\
 	     "Set enviroment variables for the \
 	      ElasticBeanStalk environment")
-	eb setenv TRACE_DB="${DB_URI}" \
+	eb setenv WB_DB_URI="${DB_URI}" \
 		  WS_VERSION="${WS_VERSION}" \
 		  AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
 		  AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
@@ -77,7 +76,7 @@ eb-local: docker-ecr-login $(call print-help,eb-local,\
 			     "Runs the ElasticBeanStalk/docker \
 			      build and run locally.")
 	eb local run --envvars \
-           PORT=${PORT},TRACE_DB=${DB_URI},WS_VERSION=${WS_VERSION}
+           PORT=${PORT},WB_DB_URI=${DB_URI},WS_VERSION=${WS_VERSION}
 
 .PHONY: build
 build: docker/${DEPLOY_JAR} \
@@ -100,7 +99,7 @@ run: $(call print-help,run,"Run the application in docker (locally).")
 		--detach \
 		-e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
 		-e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
-		-e TRACE_DB=${DB_URI} \
+		-e WB_DB_URI=${DB_URI} \
 		-e WS_VERSION=${WS_VERSION} \
 		-e PORT=${PORT} \
 		${NAME}:${VERSION}

--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,11 @@ help: ; @echo $(if $(need-help),,\
 
 .PHONY: get-assembly-json
 get-assembly-json: $(call print-help,get-assembly-json,\
-	                   "Grab the latest assembly json over ftp")
+                    "Grab the latest assembly json over ftp")
 	@curl -o ./resources/ASSEMBLIES.json \
            ${WB_FTP_URL}/species/ASSEMBLIES.${WS_VERSION}.json
 
-docker/${DEPLOY_JAR}: $(call print-help,docker/app.jar,\
+docker/${DEPLOY_JAR}: $(call print-help,docker/${DEPLOY_JAR},\
 		       "Build the jar file")
 	@./scripts/build-appjar.sh
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 NAME := wormbase/datomic-to-catalyst
 VERSION ?= $(shell git describe --abbrev=0 --tags)
-LOWER_WS_VERSION = `echo $(WS_VERSION) | tr A-Z a-z`
 EBX_CONFIG := .ebextensions/.config
 DB_URI ?= $(shell sed -rn 's|value:(.*)|\1|p' \
                   ${EBX_CONFIG} | tr -d " " | head -n 1)
+WS_VERSION ?= $(shell echo ${DB_URI} | sed -rn 's|.*(WS[0-9].+).*|\1|p')
+LOWER_WS_VERSION ?= $(shell echo ${WS_VERSION} | tr A-Z a-z)
 DEPLOY_JAR := app.jar
 PORT := 3000
 WB_ACC_NUM := 357210185381
@@ -66,7 +67,6 @@ eb-setenv: $(call print-help,eb-env,\
 	     "Set enviroment variables for the \
 	      ElasticBeanStalk environment")
 	eb setenv WB_DB_URI="${DB_URI}" \
-		  WS_VERSION="${WS_VERSION}" \
 		  AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
 		  AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
 		  -e "datomic-to-catalyst"
@@ -75,8 +75,7 @@ eb-setenv: $(call print-help,eb-env,\
 eb-local: docker-ecr-login $(call print-help,eb-local,\
 			     "Runs the ElasticBeanStalk/docker \
 			      build and run locally.")
-	eb local run --envvars \
-           PORT=${PORT},WB_DB_URI=${DB_URI},WS_VERSION=${WS_VERSION}
+	eb local run --envvars PORT=${PORT},WB_DB_URI=${DB_URI}
 
 .PHONY: build
 build: docker/${DEPLOY_JAR} \
@@ -100,7 +99,6 @@ run: $(call print-help,run,"Run the application in docker (locally).")
 		-e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
 		-e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
 		-e WB_DB_URI=${DB_URI} \
-		-e WS_VERSION=${WS_VERSION} \
 		-e PORT=${PORT} \
 		${NAME}:${VERSION}
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@
 Run following commands and test each step happens correctly.
 
 ```bash
-export WS_VERSION=WS257
-export TRACE_DB="datomic:ddb://us-east-1/WS257/wormbase"
+export WB_DB_URI="datomic:ddb://us-east-1/WS257/wormbase"
 lein ring server-headless 8130
 lein do eastwood, test
 make docker-build
@@ -34,8 +33,7 @@ eb deploy
 ## Setting environment variables
 
 ```bash
-export WS_VERSION=WS257
-export TRACE_DB="datomic:ddb://us-east-1/WS257/wormbase"
+export WB_DB_URI="datomic:ddb://us-east-1/WS257/wormbase"
 ```
 
 ## Starting server in development

--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
    [org.clojure/data.json "0.2.6"]
    [org.clojure/java.jdbc "0.7.0-alpha1"]
    [ring "1.5.1"]
-   [wormbase/pseudoace "0.4.14"]]
+   [wormbase/pseudoace "0.4.15"]]
   :source-paths ["src"]
   :plugins [[lein-environ "1.1.0"]
             [lein-pprint "1.1.1"]
@@ -58,7 +58,7 @@
           :dependencies [[ring/ring-devel "1.5.1"]]
           :source-paths ["dev"]
           :env
-          {:trace-db "datomic:ddb://us-east-1/WS257/wormbase"
+          {:wb-db-uri "datomic:ddb://us-east-1/WS257/wormbase"
            :swagger-validator-url "http://localhost:8002"}
           :plugins
           [[jonase/eastwood "0.2.3"

--- a/src/rest_api/db/main.clj
+++ b/src/rest_api/db/main.clj
@@ -4,8 +4,11 @@
    [environ.core :as environ]
    [mount.core :as mount]))
 
+(defn datomic-uri []
+  (environ/env :wb-db-uri))
+
 (defn- connect []
-  (let [db-uri (environ/env :trace-db)]
+  (let [db-uri (datomic-uri)]
     (d/connect db-uri)))
 
 (defn- disconnect [conn]

--- a/src/rest_api/db/sequence.clj
+++ b/src/rest_api/db/sequence.clj
@@ -3,11 +3,12 @@
    [clojure.data.json :as json]
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [environ.core :refer [env]]
+   [pseudoace.utils :as pace-utils]
+   [rest-api.db.main :as db]
    [rest-api.db.sequencesql :as sequencesql]))
 
 (defn database-version []
-  (env :ws-version))
+  (pace-utils/wbdb-name (db/datomic-uri)))
 
 (def species-assemblies
   (->> "ASSEMBLIES.json"

--- a/src/rest_api/main.clj
+++ b/src/rest_api/main.clj
@@ -9,9 +9,6 @@
    [ring.util.http-response :as res]
    [ring.middleware.gzip :as ring-gzip]))
 
-(defn init []
-  (mount/start))
-
 (def ^:private all-routes
   "A collection of all routes to served by the application."
   [gene/routes


### PR DESCRIPTION
 * Removed the need for WS_VERSION
 * Renamed env-var `TRACE_DB` to `WB_DB_URI`
   * Datomic URI should be specified the same way in all clj projects *
     now.
 * Updated the ElasticBeanstalk .config file accordingly.

Fixes #58