### PR TITLE
Feature/phenotype widgets

### DIFF
--- a/src/rest_api/classes/gene/widgets/phenotype.clj
+++ b/src/rest_api/classes/gene/widgets/phenotype.clj
@@ -4,6 +4,8 @@
    [datomic.api :as d]
    [pseudoace.utils :as pace-utils]
    [rest-api.classes.generic :as generic]
+   [rest-api.classes.paper.core :as paper-core]
+   [rest-api.classes.phenotype.core :as phenotype-core]
    [rest-api.formatters.object :as obj]))
 
 (defn parse-int
@@ -75,284 +77,11 @@
            [?var :variation/phenotype-not-observed ?ph]
            [?ph :variation.phenotype-not-observed/phenotype ?pheno]])
 
-(defn- create-tag [label]
-  {:taxonomy "all"
-   :class "tag"
-   :label label
-   :id  label})
-
-(defn- evidence-paper [paper]
-  {:class "paper"
-   :id (:paper/id paper)
-   :taxonomy "all"
-   :label (str (obj/author-list paper)
-               ", "
-               (if (= nil (:paper/publication-date paper))
-                 ""
-                 (first (str/split (:paper/publication-date paper)
-                                   #"-"))))})
-
-(defn var-evidence [holder variation pheno]
-  (pace-utils/vmap
-    :Person_evidence
-    (seq
-      (for [person (:phenotype-info/person-evidence holder)]
-        {:class "person"
-         :id (:person/id person)
-         :label (:person/standard-name person)
-         :taxonomy "all"}))
-
-    :Curator
-    (seq (for [person (:phenotype-info/curator-confirmed holder)]
-           {:class "person"
-            :id (:person/id person)
-            :label (:person/standard-name person)
-            :taxonomy "all"}))
-
-    :Paper_evidence
-    (seq
-      (for [paper (:phenotype-info/paper-evidence holder)]
-        (evidence-paper paper)))
-
-    :Remark
-    (seq
-      (map :phenotype-info.remark/text
-           (:phenotype-info/remark holder)))
-
-    :Recessive
-    (if (contains? holder :phenotype-info/recessive)
-      "")
-
-    :Quantity_description
-    (seq
-      (map :phenotype-info.quantity-description/text
-           (:phenotype-info/quantity-description holder)))
-
-    :Dominant
-    (if
-      (contains? holder :phenotype-info/dominant) "")
-
-    :Semi_dominant
-    (if
-      (contains? holder :phenotype-info/semi-dominant)
-      (let [sd (:phenotype-info/semi-dominant holder)]
-        (remove
-          nil?
-           [(if
-             (contains? sd :evidence/person-evidence)
-             (create-tag "Person_evidence"))
-           (if
-             (contains? sd :evidence/curator-confirmed)
-             (create-tag "Curator_confirmed"))
-           (if
-             (contains? sd :evidence/paper-evidence)
-             (create-tag "Paper_evidence"))])))
-
-    :Penetrance
-    (first
-     (remove
-      nil?
-      (flatten
-       (conj
-        (if (contains? holder :phenotype-info/low)
-          (for [low-holder (:phenotype-info/low holder)
-                :let [text (:phenotype-info.low/text low-holder)]]
-            (if (not= text "")
-              text)))
-        (if
-            (contains? holder :phenotype-info/high)
-          (for [high-holder (:phenotype-info/high holder)
-                :let [text (:phenotype-info.high/text high-holder)]]
-            (if (not= text "")
-              text)))
-        (if
-            (contains? holder :phenotype-info/complete)
-          (for [complete-holder (:phenotype-info/complete holder)
-                :let [text (:phenotype-info.complete/text
-                            complete-holder)]]
-            (if (not= text "")
-              text)))))))
-
-    :Penetrance-range
-    (if (pace-utils/not-nil? (:phenotype-info/range holder))
-      (let [range-holder (:phenotype-info/range holder)]
-        (if
-          (contains? range-holder :phenotype-info.range/int-b)
-          (let [range (str/join
-            "-"
-            [(str
-               (:phenotype-info.range/int-a range-holder))
-             (str
-               (:phenotype-info.range/int-b range-holder))])]
-            (if
-              (= range "100-100")
-              "100%"
-              range))
-          (:phenotype-info.range/int-a range-holder))))
-
-    :Maternal
-    (if
-      (contains? holder :phenotype-info/maternal)
-      (create-tag
-        (obj/humanize-ident
-          (:phenotype-info.maternal/value
-            (:phenotype-info/maternal holder)))))
-
-    :Paternal
-    (if
-      (contains? holder :phenotype-info/paternal)
-      (create-tag
-        (obj/humanize-ident
-          (:phenotype-info.paternal/value
-            (:phenotype-info/paternal holder)))))
-
-    :Haplo_insufficient
-    (if
-      (contains? holder :phenotype-info/haplo-insufficient)
-      (create-tag
-        (obj/humanize-ident
-          (:phenotype-info.paternal/value
-            (:phenotype-info/haplo-insufficient holder)))))
-
-    :Variation_effect
-    (if (contains? holder :phenotype-info/variation-effect)
-      (first
-       ;; we should actually display all of them but catalyst template
-       ;; not displaying nested array
-       (for [ve (:phenotype-info/variation-effect holder)]
-         (remove
-          nil?
-          [(create-tag
-            (obj/humanize-ident
-             (:phenotype-info.variation-effect/value ve)))
-           (if
-               (contains? ve :evidence/person-evidence)
-             (create-tag "Person_evidence"))
-           (if
-               (contains? ve :evidence/curator-confirmed)
-             (create-tag "Curator_confirmed"))
-           (if
-               (contains? ve :evidence/paper-evidence)
-             (create-tag "Paper_evidence"))]))))
-
-    :Affected_by_molecule
-    (if
-      (contains? holder :phenotype-info/molecule)
-      (for [m (:phenotype-info/molecule holder)]
-        (obj/pack-obj (:phenotype-info.molecule/molecule m))))
-
-    :Affected_by_pathogen
-    (if
-      (contains? holder :phenotype-info/pathogen)
-      (for [m (:phenotype-info/pathogen holder)]
-        (obj/pack-obj (:phenotype-info.molecule/species m))))
-
-    :Ease_of_scoring
-    (if
-      (contains? holder :phenotype-info/ease-of-scoring)
-      (create-tag
-        (obj/humanize-ident
-          (:phenotype-info.ease-of-scoring/value
-            (:phenotype-info/ease-of-scoring holder)))))
-
-    :Phenotype_assay
-    (if
-      (contains? pheno :phenotype/assay)
-      (let [holder (:phenotype/assay pheno)]
-        (:phenotype.assay/text holder)))
-
-    :Male_mating_efficiency
-    (if
-      (contains? variation :variation/male-mating-efficiency)
-      (obj/humanize-ident
-        (:variation.male-mating-efficiency/value
-          (:variation/male-mating-efficiency variation))))
-
-
-    :Temperature_sensitive
-    (if
-      (or
-        (contains? holder :phenotype-info/heat-sensitive)
-        (contains? holder :phenotype-info/cold-sensitive))
-        (conj
-          (if (contains? holder :phenotype-info/heat-sensitive)
-            (create-tag "Heat-sensitive"))
-          (if (contains? holder :phenotype-info/cold-sensitive)
-            (create-tag "Cold-sensitive"))))
-
-    :Strain
-    nil
-
-    :Treatment
-    (if
-      (contains? holder :phenotype-info/treatment)
-      (first (for [treatment-holder (:phenotype-info/treatment holder)
-    	:let [text (:phenotype-info.treatment/text treatment-holder)]]
-        (if (= text "") nil text))))
-
-    :Temperature
-    (if
-      (contains? holder :phenotype-info/temperature)
-      (first (for [temp-holder (:phenotype-info/temperature holder)
-    	:let [text (:phenotype-info.temperature/text temp-holder)]]
-        (if (= text "") nil text))))
-
-    :Ease_of_scoring
-    nil))
-
-(defn- create-pato-term [id label entity-term entity-type pato-term]
-  (let [pato-id  (str/join "_" [id label pato-term])]
-    {pato-id
-     {:pato_evidence
-      {:entity_term entity-term
-       :entity_type label
-       :pato_term pato-term}
-      :key pato-id}}))
-
-(defn- get-pato-from-holder [holder]
-  (let [sot (for [eq-annotations {"anatomy-term" "anatomy-term"
-                                  "life-stage" "life-stage"
-                                  "go-term" "go-term"
-                                  "molecule-affected" "molecule"}
-                  :let [[eq-key label] eq-annotations]]
-              (for [eq-term ((keyword "phenotype-info" eq-key) holder)]
-                (let [make-pi-kw (partial keyword
-                                       (str "phenotype-info." eq-key))
-                      pato-term-kw (make-pi-kw "pato-term")
-                      label-kw (make-pi-kw label)
-                      eq-kw (make-pi-kw eq-key)
-                      pato-names (:pato-term/name (-> eq-term
-                                                      (pato-term-kw)))
-                      pato-name (first pato-names)
-                      id ((keyword eq-key "id") (-> eq-term (eq-kw)))
-                      entity-term (obj/pack-obj label
-                                                (-> eq-term (label-kw)))
-                      pato-term (if (nil? pato-name)
-                                  "abnormal"
-                                  pato-name)]
-                  (if (pace-utils/not-nil? id)
-                    (create-pato-term id
-                                      label
-                                      entity-term
-                                      (str/capitalize
-                                       (str/replace eq-key #"-" "_"))
-                                      pato-term)))))
-        var-combo (into {} (for [x sot]
-                             (apply merge x)))]
-    {(str/join "_" (sort (keys var-combo))) (vals var-combo)}))
-
-(defn- get-pato-combinations [db pid phenos]
-  (if-let [tp (phenos pid)]
-    (let [patos (for [t tp
-                      :let [holder (d/entity db t)]]
-                  (get-pato-from-holder holder))]
-      (apply merge patos))))
-
 (defn- get-pato-combinations-gene [db pid rnai-phenos var-phenos not?]
   (if-let [vp (distinct (concat (rnai-phenos pid) (var-phenos pid)))]
     (let [patos (for [v vp
                       :let [holder (d/entity db v)]]
-                     (get-pato-from-holder holder))]
+                     (phenotype-core/get-pato-from-holder holder))]
       (apply merge patos))))
 
 (def ^{:private true} pt-info-kw (partial keyword "phenotype-info"))
@@ -452,7 +181,7 @@
        (for [t tp
              :let [holder (d/entity db t)
                    transgene (:transgene/_phenotype holder)
-                   pato-keys (keys (get-pato-from-holder holder))
+                   pato-keys (keys (phenotype-core/get-pato-from-holder holder))
                    trans-pato-key (first pato-keys)]]
          (if (= pato-key trans-pato-key)
            {:text
@@ -460,7 +189,7 @@
              :id (:transgene/id transgene)
              :label (:transgene/public-name transgene)
              :taxonomy "c_elegans"}
-            :evidence (var-evidence holder transgene pheno)})))))
+            :evidence (phenotype-core/var-evidence holder transgene pheno)})))))
 
 (defn- phenotype-table-entity
   [db pheno pato-key entity pid var-phenos rnai-phenos not-observed?]
@@ -480,7 +209,7 @@
                           :variation/_phenotype-not-observed
                           :variation/_phenotype)
                         holder)
-                   pato-keys (keys (get-pato-from-holder holder))
+                   pato-keys (keys (phenotype-core/get-pato-from-holder holder))
                    var-pato-key (first pato-keys)]]
          (if (= pato-key var-pato-key)
            {:text
@@ -492,12 +221,12 @@
                       "font-weight:bold"
                       0)
              :taxonomy "c_elegans"}
-            :evidence (var-evidence holder var pheno)})))
+            :evidence (phenotype-core/var-evidence holder var pheno)})))
      "RNAi:"
      (if-let [rp (seq (rnai-phenos pid))]
        (for [r rp]
          (let [holder (d/entity db r)
-               pato-keys (keys (get-pato-from-holder holder))
+               pato-keys (keys (phenotype-core/get-pato-from-holder holder))
                rnai ((if not-observed?
                        :rnai/_phenotype-not-observed
                        :rnai/_phenotype) holder)
@@ -519,8 +248,8 @@
                 :paper
                 (let [paper-ref (:rnai/reference rnai)]
                   (if-let [paper (:rnai.reference/paper paper-ref)]
-                    (evidence-paper paper)))}
-               (var-evidence holder rnai pheno))})))))})
+                    (paper-core/evidence paper)))}
+               (phenotype-core/var-evidence holder rnai pheno))})))))})
 
 (defn- phenotype-table-overexpressed [db gene]
   (let [trans-phenos (into {} (d/q
@@ -530,7 +259,7 @@
       (flatten
         (for [pid (keys trans-phenos)
               :let [pheno (d/entity db pid)]]
-          (let [pcs (get-pato-combinations
+          (let [pcs (phenotype-core/get-pato-combinations
                       db
                       pid
                       trans-phenos)]
@@ -551,41 +280,6 @@
                   pid
                   trans-phenos))))))
       (into  []))))
-
-(defn- phenotype-table-var [db gene not-observed?]
-  (let [var-phenos (into {} (d/q (if not-observed?
-                                   q-gene-var-not-pheno
-                                   q-gene-var-pheno)
-                                 db gene))]
-    (->> (flatten
-           (for [pid (keys var-phenos)
-                 :let [pheno (d/entity db pid)]]
-             (let [pcs (get-pato-combinations
-                         db
-                         pid
-                         var-phenos)]
-               (if (nil? pcs)
-                 (phenotype-table-entity db
-                                         pheno
-                                         nil
-                                         nil
-                                         pid
-                                         var-phenos
-                                         rnai-phenos
-                                         not-observed?)
-                 (for [[pato-key entity] pcs]
-                   (phenotype-table-entity db
-                                           pheno
-                                           pato-key
-                                           entity
-                                           pid
-                                           var-phenos
-                                           rnai-phenos
-                                           not-observed?))))))
-         (into []))))
-
-
-
 
 (defn- phenotype-table [db gene not-observed?]
   (let [var-phenos (into {} (d/q (if not-observed?

--- a/src/rest_api/classes/gene/widgets/phenotype.clj
+++ b/src/rest_api/classes/gene/widgets/phenotype.clj
@@ -189,7 +189,7 @@
              :id (:transgene/id transgene)
              :label (:transgene/public-name transgene)
              :taxonomy "c_elegans"}
-            :evidence (phenotype-core/var-evidence holder transgene pheno)})))))
+            :evidence (phenotype-core/get-evidence holder transgene pheno)})))))
 
 (defn- phenotype-table-entity
   [db pheno pato-key entity pid var-phenos rnai-phenos not-observed?]
@@ -221,7 +221,7 @@
                       "font-weight:bold"
                       0)
              :taxonomy "c_elegans"}
-            :evidence (phenotype-core/var-evidence holder var pheno)})))
+            :evidence (phenotype-core/get-evidence holder var pheno)})))
      "RNAi:"
      (if-let [rp (seq (rnai-phenos pid))]
        (for [r rp]
@@ -249,7 +249,7 @@
                 (let [paper-ref (:rnai/reference rnai)]
                   (if-let [paper (:rnai.reference/paper paper-ref)]
                     (paper-core/evidence paper)))}
-               (phenotype-core/var-evidence holder rnai pheno))})))))})
+               (phenotype-core/get-evidence holder rnai pheno))})))))})
 
 (defn- phenotype-table-overexpressed [db gene]
   (let [trans-phenos (into {} (d/q

--- a/src/rest_api/classes/gene/widgets/phenotype.clj
+++ b/src/rest_api/classes/gene/widgets/phenotype.clj
@@ -168,11 +168,11 @@
 
 (defn- phenotype-table-entity-overexpressed
   [db pheno pato-key entity pid trans-phenos]
-   :entity entity
+  {:entity entity
    :phenotype {:class "phenotype"
                :id (:phenotype/id pheno)
                :label (:phenotype.primary-name/text
-                       (:phenotype/primary-name pheno))
+                        (:phenotype/primary-name pheno))
                :taxonomy "all"}
    :evidence
    (pace-utils/vmap
@@ -189,7 +189,7 @@
              :id (:transgene/id transgene)
              :label (:transgene/public-name transgene)
              :taxonomy "c_elegans"}
-            :evidence (phenotype-core/get-evidence holder transgene pheno)})))))
+            :evidence (phenotype-core/get-evidence holder transgene pheno)}))))})
 
 (defn- phenotype-table-entity
   [db pheno pato-key entity pid var-phenos rnai-phenos not-observed?]

--- a/src/rest_api/classes/paper/core.clj
+++ b/src/rest_api/classes/paper/core.clj
@@ -1,0 +1,16 @@
+(ns rest-api.classes.paper.core
+  (:require
+   [clojure.string :as str]
+   [rest-api.formatters.object :as obj]))
+
+(defn evidence [paper]
+  {:class "paper"
+   :id (:paper/id paper)
+   :taxonomy "all"
+   :label (str
+            (obj/author-list paper)
+            ", "
+            (if (= nil (:paper/publication-date paper))
+              ""
+              (first (str/split (:paper/publication-date paper)
+                                #"-"))))})

--- a/src/rest_api/classes/phenotype/core.clj
+++ b/src/rest_api/classes/phenotype/core.clj
@@ -55,7 +55,7 @@
                   (get-pato-from-holder holder))]
       (apply merge patos))))
 
-(defn var-evidence [holder variation pheno]
+(defn get-evidence [holder entity pheno]
   (pace-utils/vmap
     :Person_evidence
     (seq
@@ -66,11 +66,16 @@
          :taxonomy "all"}))
 
     :Curator
-    (seq (for [person (:phenotype-info/curator-confirmed holder)]
-           {:class "person"
-            :id (:person/id person)
-            :label (:person/standard-name person)
-            :taxonomy "all"}))
+    (seq
+      (for [person (:phenotype-info/curator-confirmed holder)]
+        {:class "person"
+         :id (:person/id person)
+         :keys (keys person)
+         :kp (pr-str (d/touch person))
+         :dbid (:db/id person)
+         :h (keys holder)
+         :label (:person/standard-name person)
+         :taxonomy "all"}))
 
     :Paper_evidence
     (seq
@@ -232,10 +237,10 @@
 
     :Male_mating_efficiency
     (if
-      (contains? variation :variation/male-mating-efficiency)
+      (contains? entity :variation/male-mating-efficiency)
       (obj/humanize-ident
         (:variation.male-mating-efficiency/value
-          (:variation/male-mating-efficiency variation))))
+          (:variation/male-mating-efficiency entity))))
 
     :Temperature_sensitive
     (if

--- a/src/rest_api/classes/phenotype/core.clj
+++ b/src/rest_api/classes/phenotype/core.clj
@@ -3,46 +3,266 @@
    [clojure.string :as str]
    [datomic.api :as d]
    [pseudoace.utils :as pace-utils]
+   [rest-api.classes.paper.core :as paper-core]
+   [rest-api.formatters.object :as obj]
+   [rest-api.formatters.object :as obj :refer  [pack-obj]]))
 
+(defn- create-pato-term [id label entity-term entity-type pato-term]
+  (let [pato-id (str/join "_" [id label pato-term])]
+    {pato-id
+     {:pato_evidence
+      {:entity_term entity-term
+       :entity_type label
+       :pato_term pato-term}
+      :key pato-id}}))
 
-(defn- phenotype-table [db gene not-observed?]
-  (let [var-phenos (into {} (d/q (if not-observed?
-                                   q-gene-var-not-pheno
-                                   q-gene-var-pheno)
-                                 db gene))
-        rnai-phenos (into {} (d/q (if not-observed?
-                                    q-gene-rnai-not-pheno
-                                    q-gene-rnai-pheno)
-                                  db gene))
-        phenos (set (concat (keys var-phenos)
-                            (keys rnai-phenos)))]
-    (->>
+(defn get-pato-from-holder [holder]
+  (let [sot (for [eq-annotations {"anatomy-term" "anatomy-term"
+                                  "life-stage" "life-stage"
+                                  "go-term" "go-term"
+                                  "molecule-affected" "molecule"}
+                  :let [[eq-key label] eq-annotations]]
+              (for [eq-term ((keyword "phenotype-info" eq-key) holder)]
+                (let [make-pi-kw (partial keyword
+                                       (str "phenotype-info." eq-key))
+                      pato-term-kw (make-pi-kw "pato-term")
+                      label-kw (make-pi-kw label)
+                      eq-kw (make-pi-kw eq-key)
+                      pato-names (:pato-term/name (-> eq-term
+                                                      (pato-term-kw)))
+                      pato-name (first pato-names)
+                      id ((keyword eq-key "id") (-> eq-term (eq-kw)))
+                      entity-term (pack-obj label
+                                                (-> eq-term (label-kw)))
+                      pato-term (if (nil? pato-name)
+                                  "abnormal"
+                                  pato-name)]
+                  (if (pace-utils/not-nil? id)
+                    (create-pato-term id
+                                      label
+                                      entity-term
+                                      (str/capitalize
+                                       (str/replace eq-key #"-" "_"))
+                                      pato-term)))))
+        var-combo (into {} (for [x sot]
+                             (apply merge x)))]
+    {(str/join "_" (sort (keys var-combo))) (vals var-combo)}))
+
+(defn get-pato-combinations [db pid phenos]
+  (if-let [tp (phenos pid)]
+    (let [patos (for [t tp
+                      :let [holder (d/entity db t)]]
+                  (get-pato-from-holder holder))]
+      (apply merge patos))))
+
+(defn var-evidence [holder variation pheno]
+  (pace-utils/vmap
+    :Person_evidence
+    (seq
+      (for [person (:phenotype-info/person-evidence holder)]
+        {:class "person"
+         :id (:person/id person)
+         :label (:person/standard-name person)
+         :taxonomy "all"}))
+
+    :Curator
+    (seq (for [person (:phenotype-info/curator-confirmed holder)]
+           {:class "person"
+            :id (:person/id person)
+            :label (:person/standard-name person)
+            :taxonomy "all"}))
+
+    :Paper_evidence
+    (seq
+      (for [paper (:phenotype-info/paper-evidence holder)]
+        (paper-core/evidence paper)))
+
+    :Remark
+    (seq
+      (map :phenotype-info.remark/text
+           (:phenotype-info/remark holder)))
+
+    :Recessive
+    (if (contains? holder :phenotype-info/recessive)
+      "")
+
+    :Quantity_description
+    (seq
+      (map :phenotype-info.quantity-description/text
+           (:phenotype-info/quantity-description holder)))
+
+    :Dominant
+    (if
+      (contains? holder :phenotype-info/dominant) "")
+
+    :Semi_dominant
+    (if
+      (contains? holder :phenotype-info/semi-dominant)
+      (let [sd (:phenotype-info/semi-dominant holder)]
+        (remove
+          nil?
+           [(if
+             (contains? sd :evidence/person-evidence)
+             (obj/tag-obj "Person_evidence"))
+           (if
+             (contains? sd :evidence/curator-confirmed)
+             (obj/tag-obj "Curator_confirmed"))
+           (if
+             (contains? sd :evidence/paper-evidence)
+             (obj/tag-obj "Paper_evidence"))])))
+
+    :Penetrance
+    (first
+     (remove
+      nil?
       (flatten
-	(for [pid phenos
-	      :let [pheno (d/entity db pid)]]
-	  (let [pcs (get-pato-combinations-gene
-		      db
-		      pid
-		      rnai-phenos
-		      var-phenos
-		      not-observed?)]
-	    (if (nil? pcs)
-	      (phenotype-table-entity db
-				      pheno
-				      nil
-				      nil
-				      pid
-				      var-phenos
-				      rnai-phenos
-				      not-observed?)
-	      (for [[pato-key entity] pcs]
-		(phenotype-table-entity db
-					pheno
-					pato-key
-					entity
-					pid
-					var-phenos
-					rnai-phenos
-					not-observed?))))))
-      (into []))))
+       (conj
+        (if (contains? holder :phenotype-info/low)
+          (for [low-holder (:phenotype-info/low holder)
+                :let [text (:phenotype-info.low/text low-holder)]]
+            (if (not= text "")
+              text)))
+        (if
+            (contains? holder :phenotype-info/high)
+          (for [high-holder (:phenotype-info/high holder)
+                :let [text (:phenotype-info.high/text high-holder)]]
+            (if (not= text "")
+              text)))
+        (if
+            (contains? holder :phenotype-info/complete)
+          (for [complete-holder (:phenotype-info/complete holder)
+                :let [text (:phenotype-info.complete/text
+                            complete-holder)]]
+            (if (not= text "")
+              text)))))))
 
+    :Penetrance-range
+    (if (pace-utils/not-nil? (:phenotype-info/range holder))
+      (let [range-holder (:phenotype-info/range holder)]
+        (if
+          (contains? range-holder :phenotype-info.range/int-b)
+          (let [range (str/join
+            "-"
+            [(str
+               (:phenotype-info.range/int-a range-holder))
+             (str
+               (:phenotype-info.range/int-b range-holder))])]
+            (if
+              (= range "100-100")
+              "100%"
+              range))
+          (:phenotype-info.range/int-a range-holder))))
+
+    :Maternal
+    (if
+      (contains? holder :phenotype-info/maternal)
+      (obj/tag-obj
+        (obj/humanize-ident
+          (:phenotype-info.maternal/value
+            (:phenotype-info/maternal holder)))))
+
+    :Paternal
+    (if
+      (contains? holder :phenotype-info/paternal)
+      (obj/tag-obj
+        (obj/humanize-ident
+          (:phenotype-info.paternal/value
+            (:phenotype-info/paternal holder)))))
+
+    :Haplo_insufficient
+    (if
+      (contains? holder :phenotype-info/haplo-insufficient)
+      (obj/tag-obj
+        (obj/humanize-ident
+          (:phenotype-info.paternal/value
+            (:phenotype-info/haplo-insufficient holder)))))
+
+    :Variation_effect
+    (if (contains? holder :phenotype-info/variation-effect)
+      (first
+       ;; we should actually display all of them but catalyst template
+       ;; not displaying nested array
+       (for [ve (:phenotype-info/variation-effect holder)]
+         (remove
+          nil?
+          [(obj/tag-obj
+            (obj/humanize-ident
+             (:phenotype-info.variation-effect/value ve)))
+           (if
+               (contains? ve :evidence/person-evidence)
+             (obj/tag-obj "Person_evidence"))
+           (if
+               (contains? ve :evidence/curator-confirmed)
+             (obj/tag-obj "Curator_confirmed"))
+           (if
+               (contains? ve :evidence/paper-evidence)
+             (obj/tag-obj "Paper_evidence"))]))))
+
+    :Affected_by_molecule
+    (if
+      (contains? holder :phenotype-info/molecule)
+      (for [m (:phenotype-info/molecule holder)]
+        (pack-obj (:phenotype-info.molecule/molecule m))))
+
+    :Affected_by_pathogen
+    (if
+      (contains? holder :phenotype-info/pathogen)
+      (for [m (:phenotype-info/pathogen holder)]
+        (pack-obj (:phenotype-info.molecule/species m))))
+
+    :Ease_of_scoring
+    (if
+      (contains? holder :phenotype-info/ease-of-scoring)
+      (obj/tag-obj
+        (obj/humanize-ident
+          (:phenotype-info.ease-of-scoring/value
+            (:phenotype-info/ease-of-scoring holder)))))
+
+    :keys (keys holder)
+
+    :Caused_by_gene
+    (if
+      (contains? holder :phenotype-info/caused-by-gene)
+      (let [cbgs (:phenotype-info/caused-by-gene holder)]
+        (for [cbg cbgs]
+          (pack-obj (:phenotype-info.caused-by-gene/gene cbg)))))
+
+    :Phenotype_assay
+    (if
+      (contains? holder :phenotype-info/strain)
+      (obj/tag-obj "Strain"))
+
+    :Male_mating_efficiency
+    (if
+      (contains? variation :variation/male-mating-efficiency)
+      (obj/humanize-ident
+        (:variation.male-mating-efficiency/value
+          (:variation/male-mating-efficiency variation))))
+
+    :Temperature_sensitive
+    (if
+      (or
+        (contains? holder :phenotype-info/heat-sensitive)
+        (contains? holder :phenotype-info/cold-sensitive))
+        (conj
+          (if (contains? holder :phenotype-info/heat-sensitive)
+            (obj/tag-obj "Heat-sensitive"))
+          (if (contains? holder :phenotype-info/cold-sensitive)
+            (obj/tag-obj "Cold-sensitive"))))
+
+    :Treatment
+    (if
+      (contains? holder :phenotype-info/treatment)
+      (first (for [treatment-holder (:phenotype-info/treatment holder)
+        :let [text (:phenotype-info.treatment/text treatment-holder)]]
+        (if (= text "") nil text))))
+
+    :Temperature
+    (if
+      (contains? holder :phenotype-info/temperature)
+      (first (for [temp-holder (:phenotype-info/temperature holder)
+        :let [text (:phenotype-info.temperature/text temp-holder)]]
+        (if (= text "") nil text))))
+
+    :Ease_of_scoring
+    nil))

--- a/src/rest_api/classes/phenotype/core.clj
+++ b/src/rest_api/classes/phenotype/core.clj
@@ -1,0 +1,48 @@
+(ns rest-api.classes.phenotype.core
+  (:require
+   [clojure.string :as str]
+   [datomic.api :as d]
+   [pseudoace.utils :as pace-utils]
+
+
+(defn- phenotype-table [db gene not-observed?]
+  (let [var-phenos (into {} (d/q (if not-observed?
+                                   q-gene-var-not-pheno
+                                   q-gene-var-pheno)
+                                 db gene))
+        rnai-phenos (into {} (d/q (if not-observed?
+                                    q-gene-rnai-not-pheno
+                                    q-gene-rnai-pheno)
+                                  db gene))
+        phenos (set (concat (keys var-phenos)
+                            (keys rnai-phenos)))]
+    (->>
+      (flatten
+	(for [pid phenos
+	      :let [pheno (d/entity db pid)]]
+	  (let [pcs (get-pato-combinations-gene
+		      db
+		      pid
+		      rnai-phenos
+		      var-phenos
+		      not-observed?)]
+	    (if (nil? pcs)
+	      (phenotype-table-entity db
+				      pheno
+				      nil
+				      nil
+				      pid
+				      var-phenos
+				      rnai-phenos
+				      not-observed?)
+	      (for [[pato-key entity] pcs]
+		(phenotype-table-entity db
+					pheno
+					pato-key
+					entity
+					pid
+					var-phenos
+					rnai-phenos
+					not-observed?))))))
+      (into []))))
+

--- a/src/rest_api/classes/phenotype/core.clj
+++ b/src/rest_api/classes/phenotype/core.clj
@@ -218,8 +218,6 @@
           (:phenotype-info.ease-of-scoring/value
             (:phenotype-info/ease-of-scoring holder)))))
 
-    :keys (keys holder)
-
     :Caused_by_gene
     (if
       (contains? holder :phenotype-info/caused-by-gene)

--- a/src/rest_api/classes/phenotype/core.clj
+++ b/src/rest_api/classes/phenotype/core.clj
@@ -253,15 +253,15 @@
     (if
       (contains? holder :phenotype-info/treatment)
       (first (for [treatment-holder (:phenotype-info/treatment holder)
-        :let [text (:phenotype-info.treatment/text treatment-holder)]]
-        (if (= text "") nil text))))
+                   :let [text (:phenotype-info.treatment/text treatment-holder)]]
+               (if-not (str/blank? text) text))))
 
     :Temperature
     (if
       (contains? holder :phenotype-info/temperature)
       (first (for [temp-holder (:phenotype-info/temperature holder)
-        :let [text (:phenotype-info.temperature/text temp-holder)]]
-        (if (= text "") nil text))))
+                   :let [text (:phenotype-info.temperature/text temp-holder)]]
+               (if-not (str/blank? text) text))))
 
     :Ease_of_scoring
     nil))

--- a/src/rest_api/classes/phenotype/core.clj
+++ b/src/rest_api/classes/phenotype/core.clj
@@ -24,7 +24,7 @@
                   :let [[eq-key label] eq-annotations]]
               (for [eq-term ((keyword "phenotype-info" eq-key) holder)]
                 (let [make-pi-kw (partial keyword
-                                       (str "phenotype-info." eq-key))
+                                          (str "phenotype-info." eq-key))
                       pato-term-kw (make-pi-kw "pato-term")
                       label-kw (make-pi-kw label)
                       eq-kw (make-pi-kw eq-key)

--- a/src/rest_api/classes/phenotype/core.clj
+++ b/src/rest_api/classes/phenotype/core.clj
@@ -70,10 +70,6 @@
       (for [person (:phenotype-info/curator-confirmed holder)]
         {:class "person"
          :id (:person/id person)
-         :keys (keys person)
-         :kp (pr-str (d/touch person))
-         :dbid (:db/id person)
-         :h (keys holder)
          :label (:person/standard-name person)
          :taxonomy "all"}))
 

--- a/src/rest_api/classes/phenotype/widgets/transgene.clj
+++ b/src/rest_api/classes/phenotype/widgets/transgene.clj
@@ -2,9 +2,10 @@
   (:require
     [clojure.string :as str]
     [datomic.api :as d]
-    [pseudoace.utils :as pace-utils]))
+    [pseudoace.utils :as pace-utils]
+    [rest-api.classes.generic :as generic]))
 
 (def widget
   {:transgene nil
    :transgene_not nil
-   :name nil})
+   :name generic/name-field})

--- a/src/rest_api/classes/phenotype/widgets/transgene.clj
+++ b/src/rest_api/classes/phenotype/widgets/transgene.clj
@@ -1,0 +1,10 @@
+(ns rest-api.classes.phenotype.widgets.transgene
+  (:require
+    [clojure.string :as str]
+    [datomic.api :as d]
+    [pseudoace.utils :as pace-utils]))
+
+(def widget
+  {:transgene nil
+   :transgene_not nil
+   :name nil})

--- a/src/rest_api/classes/phenotype/widgets/variation.clj
+++ b/src/rest_api/classes/phenotype/widgets/variation.clj
@@ -1,4 +1,4 @@
-(ns rest-api.classes.phenotype.widgets.variaion
+(ns rest-api.classes.phenotype.widgets.variation
   (:require
     [clojure.string :as str]
     [datomic.api :as d]

--- a/src/rest_api/classes/phenotype/widgets/variation.clj
+++ b/src/rest_api/classes/phenotype/widgets/variation.clj
@@ -1,0 +1,10 @@
+(ns rest-api.classes.phenotype.widgets.variaion
+  (:require
+    [clojure.string :as str]
+    [datomic.api :as d]
+    [pseudoace.utils :as pace-utils]))
+
+(def widget
+  {:varaition nil
+   :variation_not nil
+   :name nil})

--- a/src/rest_api/classes/phenotype/widgets/variation.clj
+++ b/src/rest_api/classes/phenotype/widgets/variation.clj
@@ -2,9 +2,10 @@
   (:require
     [clojure.string :as str]
     [datomic.api :as d]
-    [pseudoace.utils :as pace-utils]))
+    [pseudoace.utils :as pace-utils]
+    [rest-api.classes.generic :as generic]))
 
 (def widget
   {:varaition nil
    :variation_not nil
-   :name nil})
+   :name generic/name-field})

--- a/src/rest_api/classes/rearrangement.clj
+++ b/src/rest_api/classes/rearrangement.clj
@@ -1,0 +1,9 @@
+(ns rest-api.classes.rearrangement
+  (:require
+    [rest-api.classes.rearrangement.widgets.phenotypes :as phenotypes]
+    [rest-api.routing :as routing]))
+
+(routing/defroutes
+  {:entity-class "rearrangement"
+   :widget
+   {:phenotypes phenotypes/widget}})

--- a/src/rest_api/classes/rearrangement/widgets/phenotypes.clj
+++ b/src/rest_api/classes/rearrangement/widgets/phenotypes.clj
@@ -21,24 +21,24 @@
 
 (defn- phenotype-table-entity
   [db pheno pato-key entity pid phenos not-observed?]
-  :entity entity
-  :phenotype {:class "phenotype"
-              :id (:phenotype/id pheno)
-              :label (:phenotype.primary-name/text
-                       (:phenotype/primary-name pheno))
-              :taxonomy "all"}
-  :evidence
-  (if-let [tp (seq (phenos pid))]
-    (for [t tp
-          :let [holder (d/entity db t)
-                rearrangement (if not-observed?
-                                (:rearrangement/_phenotype_not_observed holder)
-                                (:rearrangement/_phenotype holder))
-                pato-keys (keys (phenotype-core/get-pato-from-holder holder))
-                rearrangement-pato-key (first pato-keys)]]
-      (if (= pato-key rearrangement-pato-key)
-        {:text (pack-obj rearrangement)
-         :evidence (phenotype-core/get-evidence holder rearrangement pheno)}))))
+  {:entity entity
+   :phenotype {:class "phenotype"
+               :id (:phenotype/id pheno)
+               :label (:phenotype.primary-name/text
+                        (:phenotype/primary-name pheno))
+               :taxonomy "all"}
+   :evidence
+   (if-let [tp (seq (phenos pid))]
+     (for [t tp
+           :let [holder (d/entity db t)
+                 rearrangement (if not-observed?
+                                 (:rearrangement/_phenotype_not_observed holder)
+                                 (:rearrangement/_phenotype holder))
+                 pato-keys (keys (phenotype-core/get-pato-from-holder holder))
+                 rearrangement-pato-key (first pato-keys)]]
+       (if (= pato-key rearrangement-pato-key)
+         {:text (pack-obj rearrangement)
+          :evidence (phenotype-core/get-evidence holder rearrangement pheno)})))})
 
 (defn- phenotype-table [db rearrangement not-observed?]
   (let [rearrangement-phenos (into {} (d/q (if not-observed?

--- a/src/rest_api/classes/rearrangement/widgets/phenotypes.clj
+++ b/src/rest_api/classes/rearrangement/widgets/phenotypes.clj
@@ -3,9 +3,85 @@
     [clojure.string :as str]
     [datomic.api :as d]
     [pseudoace.utils :as pace-utils]
-    [rest-api.classes.generic :as generic]))
+    [rest-api.classes.phenotype.core :as phenotype-core]
+    [rest-api.classes.generic :as generic]
+    [rest-api.formatters.object :as obj :refer [pack-obj]]))
+
+(def q-rearrangement-pheno
+  '[:find ?pheno  (distinct ?ph)
+    :in $ ?r
+    :where [?r :rearrangement/phenotype ?ph]
+           [?ph :rearrangement.phenotype/phenotype ?pheno]])
+
+(def q-rearrangement-not-pheno
+  '[:find ?pheno  (distinct ?ph)
+    :in $ ?r
+    :where [?r :rearrangement/phenotype-not-observed ?ph]
+           [?ph :rearrangement.phenotype-not-observed/phenotype ?pheno]])
+
+(defn- phenotype-table-entity
+  [db pheno pato-key entity pid phenos not-observed?]
+  :entity entity
+  :phenotype {:class "phenotype"
+              :id (:phenotype/id pheno)
+              :label (:phenotype.primary-name/text
+                       (:phenotype/primary-name pheno))
+              :taxonomy "all"}
+  :evidence
+  (if-let [tp (seq (phenos pid))]
+    (for [t tp
+          :let [holder (d/entity db t)
+                rearrangement (if not-observed?
+                                (:rearrangement/_phenotype_not_observed holder)
+                                (:rearrangement/_phenotype holder))
+                pato-keys (keys (phenotype-core/get-pato-from-holder holder))
+                rearrangement-pato-key (first pato-keys)]]
+      (if (= pato-key rearrangement-pato-key)
+        {:text (pack-obj rearrangement)
+         :evidence (phenotype-core/var-evidence holder rearrangement pheno)}))))
+
+(defn- phenotype-table [db rearrangement not-observed?]
+  (let [rearrangement-phenos (into {} (d/q (if not-observed?
+                                             q-rearrangement-not-pheno
+                                             q-rearrangement-pheno)
+                                           db rearrangement))]
+    (->>
+      (flatten
+        (for [pid (keys rearrangement-phenos)
+              :let [pheno (d/entity db pid)]]
+          (let [pcs (phenotype-core/get-pato-combinations
+                      db
+                      pid
+                      rearrangement-phenos)]
+            (if (nil? pcs)
+              (phenotype-table-entity db
+                                      pheno
+                                      nil
+                                      nil
+                                      pid
+                                      rearrangement-phenos
+                                      not-observed?)
+              (for [[pato-key entity] pcs]
+                (phenotype-table-entity db
+                                        pheno
+                                        pato-key
+                                        entity
+                                        pid
+                                        rearrangement-phenos
+                                        not-observed?))))))
+      (into []))))
+
+(defn phenotypes-not-observed [rearrangement]
+  (let [data (phenotype-table (d/entity-db rearrangement) (:db/id rearrangement) true)]
+    {:data data
+     :description "phenotypes NOT observed or associated with this object"}))
+
+(defn phenotypes-observed [rearrangement]
+  (let [data (phenotype-table (d/entity-db rearrangement) (:db/id rearrangement) false)]
+    {:data data
+     :description "phenotypes annotated with this term"}))
 
 (def widget
-  {:phenotypes_not_observed nil
-   :phenotypes nil
+  {:phenotypes_not_observed phenotypes-not-observed
+   :phenotypes phenotypes-observed
    :name generic/name-field})

--- a/src/rest_api/classes/rearrangement/widgets/phenotypes.clj
+++ b/src/rest_api/classes/rearrangement/widgets/phenotypes.clj
@@ -38,7 +38,7 @@
                 rearrangement-pato-key (first pato-keys)]]
       (if (= pato-key rearrangement-pato-key)
         {:text (pack-obj rearrangement)
-         :evidence (phenotype-core/var-evidence holder rearrangement pheno)}))))
+         :evidence (phenotype-core/get-evidence holder rearrangement pheno)}))))
 
 (defn- phenotype-table [db rearrangement not-observed?]
   (let [rearrangement-phenos (into {} (d/q (if not-observed?

--- a/src/rest_api/classes/rearrangement/widgets/phenotypes.clj
+++ b/src/rest_api/classes/rearrangement/widgets/phenotypes.clj
@@ -1,0 +1,10 @@
+(ns rest-api.classes.rearrangement.widgets.phenotypes
+  (:require
+    [clojure.string :as str]
+    [datomic.api :as d]
+    [pseudoace.utils :as pace-utils]))
+
+(def widget
+  {:phenotypes_not_observed nil
+   :phenotypes nil
+   :name nil})

--- a/src/rest_api/classes/rearrangement/widgets/phenotypes.clj
+++ b/src/rest_api/classes/rearrangement/widgets/phenotypes.clj
@@ -2,9 +2,10 @@
   (:require
     [clojure.string :as str]
     [datomic.api :as d]
-    [pseudoace.utils :as pace-utils]))
+    [pseudoace.utils :as pace-utils]
+    [rest-api.classes.generic :as generic]))
 
 (def widget
   {:phenotypes_not_observed nil
    :phenotypes nil
-   :name nil})
+   :name generic/name-field})

--- a/src/rest_api/classes/strain.clj
+++ b/src/rest_api/classes/strain.clj
@@ -1,0 +1,9 @@
+(ns rest-api.classes.strain
+  (:require
+    [rest-api.classes.strain.widgets.phenotypes :as phenotypes]
+    [rest-api.routing :as routing]))
+
+(routing/defroutes
+  {:entity-class "strain"
+   :widget
+   {:phenotypes phenotypes/widget}})

--- a/src/rest_api/classes/strain/widgets/phenotypes.clj
+++ b/src/rest_api/classes/strain/widgets/phenotypes.clj
@@ -38,7 +38,7 @@
                 strain-pato-key (first pato-keys)]]
       (if (= pato-key strain-pato-key)
         {:text (pack-obj strain)
-         :evidence (phenotype-core/var-evidence holder strain pheno)}))))
+         :evidence (phenotype-core/get-evidence holder strain pheno)}))))
 
 (defn- phenotype-table [db strain not-observed?]
   (let [strain-phenos (into {} (d/q (if not-observed?

--- a/src/rest_api/classes/strain/widgets/phenotypes.clj
+++ b/src/rest_api/classes/strain/widgets/phenotypes.clj
@@ -1,0 +1,10 @@
+(ns rest-api.classes.strain.widgets.phenotypes
+  (:require
+    [clojure.string :as str]
+    [datomic.api :as d]
+    [pseudoace.utils :as pace-utils]))
+
+(def widgets
+  {:phenotypes_not_observed nil
+   :name nil
+   :phenotypes nil})

--- a/src/rest_api/classes/strain/widgets/phenotypes.clj
+++ b/src/rest_api/classes/strain/widgets/phenotypes.clj
@@ -21,24 +21,24 @@
 
 (defn- phenotype-table-entity
   [db pheno pato-key entity pid phenos not-observed?]
-  :entity entity
-  :phenotype {:class "phenotype"
-              :id (:phenotype/id pheno)
-              :label (:phenotype.primary-name/text
-                       (:phenotype/primary-name pheno))
-              :taxonomy "all"}
-  :evidence
-  (if-let [tp (seq (phenos pid))]
-    (for [t tp
-          :let [holder (d/entity db t)
-                strain  (if not-observed?
-                          (:strain/_phenotype-not-observed holder)
-                          (:strain/_phenotype holder))
-                pato-keys (keys (phenotype-core/get-pato-from-holder holder))
-                strain-pato-key (first pato-keys)]]
-      (if (= pato-key strain-pato-key)
-        {:text (pack-obj strain)
-         :evidence (phenotype-core/get-evidence holder strain pheno)}))))
+  {:entity entity
+   :phenotype {:class "phenotype"
+               :id (:phenotype/id pheno)
+               :label (:phenotype.primary-name/text
+                        (:phenotype/primary-name pheno))
+               :taxonomy "all"}
+   :evidence
+   (if-let [tp (seq (phenos pid))]
+     (for [t tp
+           :let [holder (d/entity db t)
+                 strain  (if not-observed?
+                           (:strain/_phenotype-not-observed holder)
+                           (:strain/_phenotype holder))
+                 pato-keys (keys (phenotype-core/get-pato-from-holder holder))
+                 strain-pato-key (first pato-keys)]]
+       (if (= pato-key strain-pato-key)
+         {:text (pack-obj strain)
+          :evidence (phenotype-core/get-evidence holder strain pheno)})))})
 
 (defn- phenotype-table [db strain not-observed?]
   (let [strain-phenos (into {} (d/q (if not-observed?

--- a/src/rest_api/classes/strain/widgets/phenotypes.clj
+++ b/src/rest_api/classes/strain/widgets/phenotypes.clj
@@ -6,5 +6,5 @@
 
 (def widgets
   {:phenotypes_not_observed nil
-   :name nil
+   :name generic/name-field
    :phenotypes nil})

--- a/src/rest_api/classes/strain/widgets/phenotypes.clj
+++ b/src/rest_api/classes/strain/widgets/phenotypes.clj
@@ -2,9 +2,87 @@
   (:require
     [clojure.string :as str]
     [datomic.api :as d]
-    [pseudoace.utils :as pace-utils]))
+    [pseudoace.utils :as pace-utils]
+    [rest-api.classes.phenotype.core :as phenotype-core]
+    [rest-api.classes.generic :as generic]
+    [rest-api.formatters.object :as obj :refer [pack-obj]]))
 
-(def widgets
-  {:phenotypes_not_observed nil
-   :name generic/name-field
-   :phenotypes nil})
+(def q-strain-pheno
+  '[:find ?pheno  (distinct ?ph)
+    :in $ ?s
+    :where [?s :strain/phenotype ?ph]
+           [?ph :strain.phenotype/phenotype ?pheno]])
+
+(def q-strain-not-pheno
+  '[:find ?pheno  (distinct ?ph)
+    :in $ ?s
+    :where [?s :strain/phenotype-not-observed ?ph]
+    [?ph :strain.phenotype-not-observed/phenotype ?pheno]])
+
+(defn- phenotype-table-entity
+  [db pheno pato-key entity pid phenos not-observed?]
+  :entity entity
+  :phenotype {:class "phenotype"
+              :id (:phenotype/id pheno)
+              :label (:phenotype.primary-name/text
+                       (:phenotype/primary-name pheno))
+              :taxonomy "all"}
+  :evidence
+  (if-let [tp (seq (phenos pid))]
+    (for [t tp
+          :let [holder (d/entity db t)
+                strain  (if not-observed?
+                          (:strain/_phenotype-not-observed holder)
+                          (:strain/_phenotype holder))
+                pato-keys (keys (phenotype-core/get-pato-from-holder holder))
+                strain-pato-key (first pato-keys)]]
+      (if (= pato-key strain-pato-key)
+        {:text (pack-obj strain)
+         :evidence (phenotype-core/var-evidence holder strain pheno)}))))
+
+(defn- phenotype-table [db strain not-observed?]
+  (let [strain-phenos (into {} (d/q (if not-observed?
+                                      q-strain-not-pheno
+                                      q-strain-pheno)
+                                    db strain))]
+    (->>
+      (flatten
+        (for [pid (keys strain-phenos)
+              :let [pheno (d/entity db pid)]]
+          (let [pcs (phenotype-core/get-pato-combinations
+                      db
+                      pid
+                      strain-phenos)]
+            (if (nil? pcs)
+              (phenotype-table-entity db
+                                      pheno
+                                      nil
+                                      nil
+                                      pid
+                                      strain-phenos
+                                      not-observed?
+                                      )
+              (for [[pato-key entity] pcs]
+                (phenotype-table-entity db
+                                        pheno
+                                        pato-key
+                                        entity
+                                        pid
+                                        strain-phenos
+                                        not-observed?))))))
+      (into []))))
+
+(defn phenotypes-not-observed [strain]
+  (let  [data  (phenotype-table  (d/entity-db strain)  (:db/id strain) true)]
+    {:data data
+     :description "phenotypes NOT observed or associated with this object"}))
+
+(defn phenotypes-observed [strain]
+  (let  [data  (phenotype-table  (d/entity-db strain)  (:db/id strain) false)]
+    {:data data
+     :description "phenotypes annotated with this term"}))
+
+(def widget
+  {:phenotypes_not_observed phenotypes-not-observed
+   :phenotypes phenotypes-observed
+   :name generic/name-field})

--- a/src/rest_api/classes/transgene.clj
+++ b/src/rest_api/classes/transgene.clj
@@ -1,0 +1,9 @@
+(ns rest-api.classes.transgene
+  (:require
+    [rest-api.classes.transgene.widgets.phenotypes :as phenotypes]
+    [rest-api.routing :as routing]))
+
+(routing/defroutes
+  {:entity-class "transgene"
+   :widget
+   {:phenotypes phenotypes/widget}})

--- a/src/rest_api/classes/transgene/widgets/phenotypes.clj
+++ b/src/rest_api/classes/transgene/widgets/phenotypes.clj
@@ -1,0 +1,10 @@
+(ns rest-api.classes.transgene.widgets.phenotypes
+  (:require
+    [clojure.string :as str]
+    [datomic.api :as d]
+    [pseudoace.utils :as pace-utils]))
+
+(def widget
+  {:phenotypes_not_observed nil
+   :phenotypes nil
+   :name nil})

--- a/src/rest_api/classes/transgene/widgets/phenotypes.clj
+++ b/src/rest_api/classes/transgene/widgets/phenotypes.clj
@@ -3,9 +3,85 @@
     [clojure.string :as str]
     [datomic.api :as d]
     [pseudoace.utils :as pace-utils]
-    [rest-api.classes.generic :as generic]))
+    [rest-api.classes.phenotype.core :as phenotype-core]
+    [rest-api.classes.generic :as generic]
+    [rest-api.formatters.object :as obj :refer [pack-obj]]))
+
+(def q-transgene-pheno
+  '[:find ?pheno  (distinct ?ph)
+    :in $ ?r
+    :where [?r :transgene/phenotype ?ph]
+           [?ph :transgene.phenotype/phenotype ?pheno]])
+
+(def q-transgene-not-pheno
+  '[:find ?pheno  (distinct ?ph)
+    :in $ ?r
+    :where [?r :transgene/phenotype-not-observed ?ph]
+           [?ph :transgene.phenotype-not-observed/phenotype ?pheno]])
+
+(defn- phenotype-table-entity
+  [db pheno pato-key entity pid phenos not-observed?]
+  :entity entity
+  :phenotype {:class "phenotype"
+              :id (:phenotype/id pheno)
+              :label (:phenotype.primary-name/text
+                       (:phenotype/primary-name pheno))
+              :taxonomy "all"}
+  :evidence
+  (if-let [tp (seq (phenos pid))]
+    (for [t tp
+          :let [holder (d/entity db t)
+                transgene (if not-observed?
+                            (:transgene/_phenotype_not_observed holder)
+                            (:transgene/_phenotype holder))
+                pato-keys (keys (phenotype-core/get-pato-from-holder holder))
+                transgene-pato-key (first pato-keys)]]
+      (if (= pato-key transgene-pato-key)
+        {:text (pack-obj transgene)
+         :evidence (phenotype-core/var-evidence holder transgene pheno)}))))
+
+(defn- phenotype-table [db transgene not-observed?]
+  (let [transgene-phenos (into {} (d/q (if not-observed?
+                                         q-transgene-not-pheno
+                                         q-transgene-pheno)
+                                       db transgene))]
+    (->>
+      (flatten
+        (for [pid (keys transgene-phenos)
+              :let [pheno (d/entity db pid)]]
+          (let [pcs (phenotype-core/get-pato-combinations
+                      db
+                      pid
+                      transgene-phenos)]
+            (if (nil? pcs)
+              (phenotype-table-entity db
+                                      pheno
+                                      nil
+                                      nil
+                                      pid
+                                      transgene-phenos
+                                      not-observed?)
+              (for [[pato-key entity] pcs]
+                (phenotype-table-entity db
+                                        pheno
+                                        pato-key
+                                        entity
+                                        pid
+                                        transgene-phenos
+                                        not-observed?))))))
+      (into []))))
+
+(defn phenotypes-not-observed [transgene]
+  (let [data (phenotype-table (d/entity-db transgene) (:db/id transgene) true)]
+    {:data data
+     :description "phenotypes NOT observed or associated with this object"}))
+
+(defn phenotypes-observed [transgene]
+  (let [data (phenotype-table (d/entity-db transgene) (:db/id transgene) false)]
+    {:data data
+     :description "phenotypes annotated with this term"}))
 
 (def widget
-  {:phenotypes_not_observed nil
-   :phenotypes nil
+  {:phenotypes_not_observed phenotypes-not-observed
+   :phenotypes phenotypes-observed
    :name generic/name-field})

--- a/src/rest_api/classes/transgene/widgets/phenotypes.clj
+++ b/src/rest_api/classes/transgene/widgets/phenotypes.clj
@@ -21,24 +21,24 @@
 
 (defn- phenotype-table-entity
   [db pheno pato-key entity pid phenos not-observed?]
-  :entity entity
-  :phenotype {:class "phenotype"
-              :id (:phenotype/id pheno)
-              :label (:phenotype.primary-name/text
-                       (:phenotype/primary-name pheno))
-              :taxonomy "all"}
-  :evidence
-  (if-let [tp (seq (phenos pid))]
-    (for [t tp
-          :let [holder (d/entity db t)
-                transgene (if not-observed?
-                            (:transgene/_phenotype_not_observed holder)
-                            (:transgene/_phenotype holder))
-                pato-keys (keys (phenotype-core/get-pato-from-holder holder))
-                transgene-pato-key (first pato-keys)]]
-      (if (= pato-key transgene-pato-key)
-        {:text (pack-obj transgene)
-         :evidence (phenotype-core/get-evidence holder transgene pheno)}))))
+  {:entity entity
+   :phenotype {:class "phenotype"
+               :id (:phenotype/id pheno)
+               :label (:phenotype.primary-name/text
+                        (:phenotype/primary-name pheno))
+               :taxonomy "all"}
+   :evidence
+   (if-let [tp (seq (phenos pid))]
+     (for [t tp
+           :let [holder (d/entity db t)
+                 transgene (if not-observed?
+                             (:transgene/_phenotype_not_observed holder)
+                             (:transgene/_phenotype holder))
+                 pato-keys (keys (phenotype-core/get-pato-from-holder holder))
+                 transgene-pato-key (first pato-keys)]]
+       (if (= pato-key transgene-pato-key)
+         {:text (pack-obj transgene)
+          :evidence (phenotype-core/get-evidence holder transgene pheno)})))})
 
 (defn- phenotype-table [db transgene not-observed?]
   (let [transgene-phenos (into {} (d/q (if not-observed?

--- a/src/rest_api/classes/transgene/widgets/phenotypes.clj
+++ b/src/rest_api/classes/transgene/widgets/phenotypes.clj
@@ -38,7 +38,7 @@
                 transgene-pato-key (first pato-keys)]]
       (if (= pato-key transgene-pato-key)
         {:text (pack-obj transgene)
-         :evidence (phenotype-core/var-evidence holder transgene pheno)}))))
+         :evidence (phenotype-core/get-evidence holder transgene pheno)}))))
 
 (defn- phenotype-table [db transgene not-observed?]
   (let [transgene-phenos (into {} (d/q (if not-observed?

--- a/src/rest_api/classes/transgene/widgets/phenotypes.clj
+++ b/src/rest_api/classes/transgene/widgets/phenotypes.clj
@@ -27,18 +27,17 @@
                :label (:phenotype.primary-name/text
                         (:phenotype/primary-name pheno))
                :taxonomy "all"}
-   :evidence
-   (if-let [tp (seq (phenos pid))]
-     (for [t tp
-           :let [holder (d/entity db t)
-                 transgene (if not-observed?
-                             (:transgene/_phenotype_not_observed holder)
-                             (:transgene/_phenotype holder))
-                 pato-keys (keys (phenotype-core/get-pato-from-holder holder))
-                 transgene-pato-key (first pato-keys)]]
-       (if (= pato-key transgene-pato-key)
-         {:text (pack-obj transgene)
-          :evidence (phenotype-core/get-evidence holder transgene pheno)})))})
+   :evidence (if-let [tp (seq (phenos pid))]
+               (for [t tp
+                     :let [holder (d/entity db t)
+                           transgene (if not-observed?
+                                       (:transgene/_phenotype_not_observed holder)
+                                       (:transgene/_phenotype holder))
+                           pato-keys (keys (phenotype-core/get-pato-from-holder holder))
+                           transgene-pato-key (first pato-keys)]]
+                 (if (= pato-key transgene-pato-key)
+                   {:text (pack-obj transgene)
+                    :evidence (phenotype-core/get-evidence holder transgene pheno)})))})
 
 (defn- phenotype-table [db transgene not-observed?]
   (let [transgene-phenos (into {} (d/q (if not-observed?

--- a/src/rest_api/classes/transgene/widgets/phenotypes.clj
+++ b/src/rest_api/classes/transgene/widgets/phenotypes.clj
@@ -2,9 +2,10 @@
   (:require
     [clojure.string :as str]
     [datomic.api :as d]
-    [pseudoace.utils :as pace-utils]))
+    [pseudoace.utils :as pace-utils]
+    [rest-api.classes.generic :as generic]))
 
 (def widget
   {:phenotypes_not_observed nil
    :phenotypes nil
-   :name nil})
+   :name generic/name-field})

--- a/src/rest_api/classes/variation.clj
+++ b/src/rest_api/classes/variation.clj
@@ -1,9 +1,11 @@
 (ns rest-api.classes.variation
   (:require
+    [rest-api.classes.variation.widgets.phenotypes :as phenotypes]
     [rest-api.classes.gene.widgets.external-links :as external-links]
     [rest-api.routing :as routing]))
 
 (routing/defroutes
   {:entity-class "variation"
    :widget
-   {:external_links external-links/widget}})
+   {:phenotypes phenotypes/widget
+    :external_links external-links/widget}})

--- a/src/rest_api/classes/variation/widgets/phenotypes.clj
+++ b/src/rest_api/classes/variation/widgets/phenotypes.clj
@@ -83,7 +83,6 @@
      :description "phenotypes annotated with this term"}))
 
 (def widget
-  {
- ;;  :phenotypes_not_observed phenotypes-not-observed
+  {:phenotypes_not_observed phenotypes-not-observed
    :phenotypes phenotypes-observed
    :name generic/name-field})

--- a/src/rest_api/classes/variation/widgets/phenotypes.clj
+++ b/src/rest_api/classes/variation/widgets/phenotypes.clj
@@ -1,0 +1,10 @@
+(ns rest-api.classes.variation.widgets.phenotypes
+  (:require
+    [clojure.string :as str]
+    [datomic.api :as d]
+    [pseudoace.utils :as pace-utils]))
+
+(def widget
+  {:phenotypes_not_observed nil
+   :name nil
+   :phenotpes nil})

--- a/src/rest_api/classes/variation/widgets/phenotypes.clj
+++ b/src/rest_api/classes/variation/widgets/phenotypes.clj
@@ -3,9 +3,87 @@
     [clojure.string :as str]
     [datomic.api :as d]
     [pseudoace.utils :as pace-utils]
-    [rest-api.classes.generic :as generic]))
+    [rest-api.classes.phenotype.core :as phenotype-core]
+    [rest-api.classes.generic :as generic]
+    [rest-api.formatters.object :as obj :refer  [pack-obj]]))
+
+(def q-variation-pheno
+  '[:find ?pheno (distinct ?ph)
+    :in $ ?var
+    :where [?var :variation/phenotype ?ph]
+           [?ph :variation.phenotype/phenotype ?pheno]])
+
+(def q-variation-not-pheno
+  '[:find ?pheno (distinct ?ph)
+    :in $ ?var
+    :where [?var :variation/phenotype-not-observed ?ph]
+           [?ph :variation.phenotype-not-observed/phenotype ?pheno]])
+
+(defn- phenotype-table-entity
+  [db pheno pato-key entity pid phenos not-observed?]
+  {:entity entity
+   :phenotype {:class "phenotype"
+               :id (:phenotype/id pheno)
+               :label (:phenotype.primary-name/text
+                        (:phenotype/primary-name pheno))
+               :taxonomy "all"}
+   :evidence
+   (if-let [tp (seq (phenos pid))]
+     (for [t tp
+           :let [holder (d/entity db t)
+                 variation (if not-observed?
+                             (:variation/_phenotype-not-observed holder)
+                             (:variation/_phenotype holder))
+                 pato-keys (keys (phenotype-core/get-pato-from-holder holder))
+                 variation-pato-key (first pato-keys)]]
+       (if (= pato-key variation-pato-key)
+         {:text (pack-obj variation)
+          :evidence (phenotype-core/var-evidence holder variation pheno)})))})
+
+(defn- phenotype-table [db variation not-observed?]
+  (let [variation-phenos (into {} (d/q (if not-observed?
+                                         q-variation-not-pheno
+                                         q-variation-pheno)
+                                       db variation))]
+    (->>
+      (flatten
+        (for [pid (keys variation-phenos)
+              :let [pheno (d/entity db pid)]]
+          (let [pcs (phenotype-core/get-pato-combinations
+                      db
+                      pid
+                      variation-phenos)]
+            (if (nil? pcs)
+              (phenotype-table-entity db
+                                      pheno
+                                      nil
+                                      nil
+                                      pid
+                                      variation-phenos
+                                      not-observed?
+                                      )
+              (for [[pato-key entity] pcs]
+                (phenotype-table-entity db
+                                        pheno
+                                        pato-key
+                                        entity
+                                        pid
+                                        variation-phenos
+                                        not-observed?))))))
+      (into []))))
+
+(defn phenotypes-not-observed [variation]
+  (let [data (phenotype-table (d/entity-db variation) (:db/id variation) true)]
+    {:data data
+     :description "phenotypes NOT observed or associated with this object"}))
+
+(defn phenotypes-observed [variation]
+  (let [data (phenotype-table (d/entity-db variation) (:db/id variation) false)]
+    {:data data
+     :description "phenotypes annotated with this term"}))
 
 (def widget
-  {:phenotypes_not_observed nil
-   :name generic/name-field
-   :phenotpes nil})
+  {
+ ;;  :phenotypes_not_observed phenotypes-not-observed
+   :phenotypes phenotypes-observed
+   :name generic/name-field})

--- a/src/rest_api/classes/variation/widgets/phenotypes.clj
+++ b/src/rest_api/classes/variation/widgets/phenotypes.clj
@@ -2,9 +2,10 @@
   (:require
     [clojure.string :as str]
     [datomic.api :as d]
-    [pseudoace.utils :as pace-utils]))
+    [pseudoace.utils :as pace-utils]
+    [rest-api.classes.generic :as generic]))
 
 (def widget
   {:phenotypes_not_observed nil
-   :name nil
+   :name generic/name-field
    :phenotpes nil})

--- a/src/rest_api/classes/variation/widgets/phenotypes.clj
+++ b/src/rest_api/classes/variation/widgets/phenotypes.clj
@@ -38,7 +38,7 @@
                  variation-pato-key (first pato-keys)]]
        (if (= pato-key variation-pato-key)
          {:text (pack-obj variation)
-          :evidence (phenotype-core/var-evidence holder variation pheno)})))})
+          :evidence (phenotype-core/get-evidence holder variation pheno)})))})
 
 (defn- phenotype-table [db variation not-observed?]
   (let [variation-phenos (into {} (d/q (if not-observed?

--- a/src/rest_api/classes/wbprocess.clj
+++ b/src/rest_api/classes/wbprocess.clj
@@ -1,0 +1,9 @@
+(ns rest-api.classes.wbprocess
+  (:require
+    [rest-api.classes.wbprocess.widgets.phenotypes :as phenotypes]
+    [rest-api.routing :as routing]))
+
+(routing/defroutes
+  {:entity-class "wbprocess"
+   :widget
+   {:phenotypes phenotypes/widget}})

--- a/src/rest_api/classes/wbprocess/widgets/phenotypes.clj
+++ b/src/rest_api/classes/wbprocess/widgets/phenotypes.clj
@@ -30,7 +30,7 @@
                  wbprocess-pato-key (first pato-keys)]]
        (if (= pato-key wbprocess-pato-key)
          {:text (pack-obj wbprocess)
-          :evidence (phenotype-core/var-evidence holder wbprocess pheno)})))})
+          :evidence (phenotype-core/get-evidence holder wbprocess pheno)})))})
 
 (defn- phenotype-table [db wbprocess]
   (let [phenos (into {} (d/q q-wbprocess-pheno

--- a/src/rest_api/classes/wbprocess/widgets/phenotypes.clj
+++ b/src/rest_api/classes/wbprocess/widgets/phenotypes.clj
@@ -1,0 +1,69 @@
+(ns rest-api.classes.wbprocess.widgets.phenotypes
+  (:require
+    [clojure.string :as str]
+    [datomic.api :as d]
+    [pseudoace.utils :as pace-utils]
+    [rest-api.classes.phenotype.core :as phenotype-core]
+    [rest-api.classes.generic :as generic]
+    [rest-api.formatters.object :as obj :refer  [pack-obj]]))
+
+(def q-wbprocess-pheno
+  '[:find ?pheno (distinct ?ph)
+    :in $ ?wbp
+    :where [?wbp :wbprocess/phenotype ?ph]
+           [?ph :wbprocess.phenotype/phenotype ?pheno]])
+
+(defn- phenotype-table-entity
+  [db pheno pato-key entity pid phenos]
+  {:entity entity
+   :phenotype {:class "phenotype"
+               :id (:phenotype/id pheno)
+               :label (:phenotype.primary-name/text
+                        (:phenotype/primary-name pheno))
+               :taxonomy "all"}
+   :evidence
+   (if-let [tp (seq (phenos pid))]
+     (for [t tp
+           :let [holder (d/entity db t)
+                 wbprocess (:wbprocess/_phenotype holder)
+                 pato-keys (keys (phenotype-core/get-pato-from-holder holder))
+                 wbprocess-pato-key (first pato-keys)]]
+       (if (= pato-key wbprocess-pato-key)
+         {:text (pack-obj wbprocess)
+          :evidence (phenotype-core/var-evidence holder wbprocess pheno)})))})
+
+(defn- phenotype-table [db wbprocess]
+  (let [phenos (into {} (d/q q-wbprocess-pheno
+                             db wbprocess))]
+    (->>
+      (flatten
+        (for [pid (keys phenos)
+              :let [pheno (d/entity db pid)]]
+          (let [pcs (phenotype-core/get-pato-combinations
+                      db
+                      pid
+                      phenos)]
+            (if (nil? pcs)
+              (phenotype-table-entity db
+                                      pheno
+                                      nil
+                                      nil
+                                      pid
+                                      phenos)
+              (for [[pato-key entity] pcs]
+                (phenotype-table-entity db
+                                        pheno
+                                        pato-key
+                                        entity
+                                        pid
+                                        phenos))))))
+      (into []))))
+
+(defn phenotypes-observed [wbprocess]
+  (let [data (phenotype-table (d/entity-db wbprocess) (:db/id wbprocess))]
+    {:data data
+     :description "phenotypes annotated with this term"}))
+
+(def widget
+  {:phenotypes phenotypes-observed
+   :name generic/name-field})

--- a/src/rest_api/formatters/object.clj
+++ b/src/rest_api/formatters/object.clj
@@ -374,3 +374,9 @@
     {:data (not-empty data)
      :description (format "The name and WormBase internal ID of %s"
                           (:id data))}))
+
+(defn tag-obj [label]
+  {:taxonomy "all"
+   :class "tag"
+   :label label
+   :id label})

--- a/src/rest_api/main.clj
+++ b/src/rest_api/main.clj
@@ -9,6 +9,9 @@
    [rest-api.classes.anatomy-term :as anatomy-term]
    [rest-api.classes.analysis :as analysis]
    [rest-api.classes.variation :as variation]
+   [rest-api.classes.transgene :as transgene]
+   [rest-api.classes.strain :as strain]
+   [rest-api.classes.rearrangement :as rearrangement]
    [rest-api.classes.cds :as cds]
    [rest-api.classes.clone :as clone]
    [rest-api.classes.disease :as disease]
@@ -32,6 +35,9 @@
    anatomy-term/routes
    analysis/routes
    variation/routes
+   transgene/routes
+   strain/routes
+   rearrangement/routes
    cds/routes
    clone/routes
    disease/routes

--- a/src/rest_api/main.clj
+++ b/src/rest_api/main.clj
@@ -11,6 +11,7 @@
    [rest-api.classes.variation :as variation]
    [rest-api.classes.transgene :as transgene]
    [rest-api.classes.strain :as strain]
+   [rest-api.classes.wbprocess :as wbprocess]
    [rest-api.classes.rearrangement :as rearrangement]
    [rest-api.classes.cds :as cds]
    [rest-api.classes.clone :as clone]
@@ -37,6 +38,7 @@
    variation/routes
    transgene/routes
    strain/routes
+   wbprocess/routes
    rearrangement/routes
    cds/routes
    clone/routes


### PR DESCRIPTION
This pull request contains "Phenotypes" widgets for the pages:
- Variation
- Strain
- Rearrangement
- RNAi
- Transgene
- WBProcess

These widgets have to following changes from the originals: 
- They do not contain description columns data (Sibly has remove this column form Catalyst and it was a request from curators)
- I have added in a "Phenotype_not_observed" table to all pages but WBProcess. Some pages, including "Strain" do not have this table even though the field is in the database. I have discussed this with Karen Yook and she will be looking into adding the "phenotypes_not_observed" field into the schema in future version of the database. I think this would especially be good for consistency.

I have tested this code by going through information to see if it make sense and to see if it reasonably lines up with data found on the database. The major thing that I know isn't working with the WS258 database is consistently populating the curators name.

Once this is pulled, the WS259 is generated and the curators have a chance to check the changes I will create some official tests. 