### PR TITLE
Feature/entity alias uri

### DIFF
--- a/src/rest_api/classes/analysis.clj
+++ b/src/rest_api/classes/analysis.clj
@@ -4,6 +4,6 @@
     [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:entity-class "analysis"
+  {:entity-ns "analysis"
    :widget
    {:external_links external-links/widget}})

--- a/src/rest_api/classes/anatomy_term.clj
+++ b/src/rest_api/classes/anatomy_term.clj
@@ -4,6 +4,6 @@
     [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:entity-class "anatomy-term"
+  {:entity-ns "anatomy-term"
    :widget
    {:external_links external-links/widget}})

--- a/src/rest_api/classes/cds.clj
+++ b/src/rest_api/classes/cds.clj
@@ -4,6 +4,6 @@
     [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:entity-class "cds"
+  {:entity-ns "cds"
    :widget
    {:external_links external-links/widget}})

--- a/src/rest_api/classes/clone.clj
+++ b/src/rest_api/classes/clone.clj
@@ -4,6 +4,6 @@
     [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:entity-class "clone"
+  {:entity-ns "clone"
    :widget
    {:external_links external-links/widget}})

--- a/src/rest_api/classes/disease.clj
+++ b/src/rest_api/classes/disease.clj
@@ -4,6 +4,6 @@
     [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:entity-class "disease"
+  {:entity-ns "disease"
    :widget
    {:external_links external-links/widget}})

--- a/src/rest_api/classes/gene.clj
+++ b/src/rest_api/classes/gene.clj
@@ -19,7 +19,7 @@
    [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:entity-class "gene"
+  {:entity-ns "gene"
    :widget
    {:external_links external-links/widget
     :expression expression/widget

--- a/src/rest_api/classes/homology_group.clj
+++ b/src/rest_api/classes/homology_group.clj
@@ -4,6 +4,6 @@
     [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:entity-class "homology-group"
+  {:entity-ns "homology-group"
    :widget
    {:external_links external-links/widget}})

--- a/src/rest_api/classes/interaction.clj
+++ b/src/rest_api/classes/interaction.clj
@@ -4,6 +4,6 @@
     [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:entity-class "interaction"
+  {:entity-ns "interaction"
    :widget
    {:external_links external-links/widget}})

--- a/src/rest_api/classes/molecule.clj
+++ b/src/rest_api/classes/molecule.clj
@@ -4,6 +4,6 @@
     [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:entity-class "molecule"
+  {:entity-ns "molecule"
    :widget
    {:external_links external-links/widget}})

--- a/src/rest_api/classes/motif.clj
+++ b/src/rest_api/classes/motif.clj
@@ -4,6 +4,6 @@
     [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:entity-class "motif"
+  {:entity-ns "motif"
    :widget
    {:external_links external-links/widget}})

--- a/src/rest_api/classes/paper.clj
+++ b/src/rest_api/classes/paper.clj
@@ -4,6 +4,6 @@
     [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:entity-class "paper"
+  {:entity-ns "paper"
    :widget
    {:external_links external-links/widget}})

--- a/src/rest_api/classes/person.clj
+++ b/src/rest_api/classes/person.clj
@@ -7,7 +7,7 @@
     [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:entity-class "person"
+  {:entity-ns "person"
    :widget
    {
     :laboratory laboratory/widget

--- a/src/rest_api/classes/protein.clj
+++ b/src/rest_api/classes/protein.clj
@@ -4,6 +4,6 @@
     [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:entity-class "protein"
+  {:entity-ns "protein"
    :widget
    {:external_links external-links/widget}})

--- a/src/rest_api/classes/rearrangement.clj
+++ b/src/rest_api/classes/rearrangement.clj
@@ -4,6 +4,6 @@
     [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:entity-class "rearrangement"
+  {:entity-ns "rearrangement"
    :widget
    {:phenotypes phenotypes/widget}})

--- a/src/rest_api/classes/rnai.clj
+++ b/src/rest_api/classes/rnai.clj
@@ -5,7 +5,7 @@
     [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:entity-class "rnai"
+  {:entity-ns "rnai"
    :widget
    {:phenotypes phenotypes/widget
     :external_links external-links/widget}})

--- a/src/rest_api/classes/sequence.clj
+++ b/src/rest_api/classes/sequence.clj
@@ -4,6 +4,6 @@
     [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:entity-class "sequence"
+  {:entity-ns "sequence"
    :widget
    {:external_links external-links/widget}})

--- a/src/rest_api/classes/strain.clj
+++ b/src/rest_api/classes/strain.clj
@@ -4,6 +4,6 @@
     [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:entity-class "strain"
+  {:entity-ns "strain"
    :widget
    {:phenotypes phenotypes/widget}})

--- a/src/rest_api/classes/structure_data.clj
+++ b/src/rest_api/classes/structure_data.clj
@@ -4,6 +4,6 @@
     [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:entity-class "structure-data"
+  {:entity-ns "structure-data"
    :widget
    {:external_links external-links/widget}})

--- a/src/rest_api/classes/transcript.clj
+++ b/src/rest_api/classes/transcript.clj
@@ -29,7 +29,7 @@
    :microarray_topology_map_position (delegate-to-gene exp/microarray-topology-map-position)})
 
 (routing/defroutes
-  {:entity-class "transcript"
+  {:entity-ns "transcript"
    :widget
    {:expression expression-widget
     :external_links external-links/widget}

--- a/src/rest_api/classes/transgene.clj
+++ b/src/rest_api/classes/transgene.clj
@@ -4,6 +4,6 @@
     [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:entity-class "transgene"
+  {:entity-ns "transgene"
    :widget
    {:phenotypes phenotypes/widget}})

--- a/src/rest_api/classes/variation.clj
+++ b/src/rest_api/classes/variation.clj
@@ -5,7 +5,7 @@
     [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:entity-class "variation"
+  {:entity-ns "variation"
    :widget
    {:phenotypes phenotypes/widget
     :external_links external-links/widget}})

--- a/src/rest_api/classes/wbprocess.clj
+++ b/src/rest_api/classes/wbprocess.clj
@@ -4,6 +4,6 @@
     [rest-api.routing :as routing]))
 
 (routing/defroutes
-  {:entity-class "wbprocess"
+  {:entity-ns "wbprocess"
    :widget
    {:phenotypes phenotypes/widget}})

--- a/src/rest_api/routing.clj
+++ b/src/rest_api/routing.clj
@@ -64,7 +64,8 @@
                        fields)
           route-data (assoc this :field field-defs)
           entity-ns (:entity-ns route-data)
-          entity-segment (str/replace entity-ns #"-" "_")]
+          entity-uri-name (get route-data :uri-name entity-ns)
+          entity-segment (str/replace entity-uri-name #"-" "_")]
       (flatten
         (for [kw [:widget :field]
               :let [scheme (name kw)

--- a/test/rest_api/test_routing.clj
+++ b/test/rest_api/test_routing.clj
@@ -81,7 +81,7 @@
       widget {:x (mk-route-spec [:a :b :c :d])
               :y (mk-route-spec [:e :f :g])}
       fields {:z (mk-route-spec [:h :i])}]
-  (routing/defroutes {:entity-class "some-entity"
+  (routing/defroutes {:entity-ns "some-entity"
                       :widget widget
                       :field fields})
 

--- a/test/rest_api/test_routing.clj
+++ b/test/rest_api/test_routing.clj
@@ -4,7 +4,8 @@
    [compojure.api.routes :as c-routes]
    [compojure.api.sweet :as sweet]
    [rest-api.db-testing :as db-testing]
-   [rest-api.routing :as routing]))
+   [rest-api.routing :as routing]
+   [clojure.string :as str]))
 
 (use-fixtures :once db-testing/db-lifecycle)
 
@@ -30,7 +31,7 @@
       (is (= 200 (:status response)))
       (is (= (:body response) expected))))
   (testing
-    "Main request handler produces correct data structure (fields)"
+    "Main request handler produces correct data structure (fields)."
     (let [req {:uri "/rest/field/gene/WBGene00000001/xrefs"
                :context "/rest/widget/gene"
                :params {:id "WBGene00000001"}}
@@ -44,6 +45,26 @@
                     :uri "rest/field/gene/WBGene00000001/xrefs"
                     :class "gene"
                     :name "WBGene00000001"}]
+      (is (= (:body response) expected))))
+  (testing
+      "Entity namespace can be aliased in request URI."
+    (let [entity-id "DOID:7"
+          entity-ns "do-term"
+          req {:uri "/rest/widget/disease/DOID:7/overview"
+               :context "/rest/widget/disease"
+               :params {:id entity-id}}
+          disease-overview {:data {:info "Disease info"}
+                            :description "Some disease"}
+          entity-handler (fn [e]
+                           disease-overview)
+          widgets {:overview entity-handler}
+          handler (routing/make-request-handler :widget widgets
+                                                entity-ns)
+          response (handler req)
+          expected {:uri "rest/widget/disease/DOID:7/overview"
+                    :class entity-ns
+                    :name entity-id
+                    :fields {:overview disease-overview}}]
       (is (= (:body response) expected)))))
 
 (deftest test-conform-to-scheme
@@ -82,6 +103,7 @@
               :y (mk-route-spec [:e :f :g])}
       fields {:z (mk-route-spec [:h :i])}]
   (routing/defroutes {:entity-ns "some-entity"
+                      :uri-name "different_to_entity_namespace"
                       :widget widget
                       :field fields})
 


### PR DESCRIPTION
Allows a different name in the URI to that of the entity namespace.
e.g: "do-term" and "/disease/"
Adds unit tests for routing.
Renames the `:entity-class` keyword to `:entity-ns` as I think makes more sense (datomic verbage)
Alias can be specified under a new (optional) key in the mapping passed to `routing/defroutes` via `:uri-name`.