### PR TITLE
Bugfix/interaction details performance fix 1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -55,7 +55,8 @@
            ["do"
             ["eastwood"]
             "test"]}
-          :dependencies [[ring/ring-devel "1.5.1"]]
+          :dependencies [[org.clojure/tools.trace "0.7.9"]
+                         [ring/ring-devel "1.5.1"]]
           :source-paths ["dev"]
           :env
           {:wb-db-uri "datomic:ddb://us-east-1/WS259/wormbase"

--- a/src/rest_api/classes/gene/widgets/interactions.clj
+++ b/src/rest_api/classes/gene/widgets/interactions.clj
@@ -127,8 +127,8 @@
   (->> (d/q '[:find ?int (count ?ng)
               :in $ % ?gene
               :where
-              (gene-interaction ?ng ?int)
-              (gene-neighbour ?gene ?ng)]
+              (gene-neighbour ?gene ?ng)
+              (gene-interaction ?ng ?int)]
             db int-rules gene)
        (filter (fn [[_ cnt]]
                  (> cnt 1)))
@@ -141,8 +141,8 @@
       (d/q '[:find (count ?ng) .
              :in $ % ?int ?gene ?ng
              :where
-             (gene-interaction ?ng ?int)
-             (gene-neighbour ?gene ?ng)]
+             (gene-neighbour ?gene ?ng)
+             (gene-interaction ?ng ?int)]
              db
              int-rules
              ix-id


### PR DESCRIPTION
Addresses performance issues for genes that have few interactions.

The queries the code were making to datomic for the "nearby" interactions were not specified correctly, causing the equivalent of a "full-table scan" in SQL - i.e was consuming all interaction entities  and filtering rather than putting the most selective statement first.