### PR TITLE
Hotfix/0.1.8 expression widget and pack-tax 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## [0.1.8] - (unreleased)
+## [0.2.0] - (unreleased)
 - 11 more overview widgets
+
+## [0.1.8] - 2017-07-25
+- Fix bug in utility functions that affects links to papers
+- Fix bug in expression widget image display
 
 ## [0.1.7] - 2017-07-05
 - Minor Bug fixes

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wormbase/rest-api "0.1.8-SNAPSHOT"
+(defproject wormbase/rest-api "0.1.8"
   :description
   "REST API for retrieving data from datomic on a per widget basis"
   :url "https://github.com/WormBase/datomic-to-catalyst"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject wormbase/rest-api "0.1.7"
+(defproject wormbase/rest-api "0.1.8-SNAPSHOT"
   :description
   "REST API for retrieving data from datomic on a per widget basis"
   :url "https://github.com/WormBase/datomic-to-catalyst"

--- a/src/rest_api/classes/gene/expression.clj
+++ b/src/rest_api/classes/gene/expression.clj
@@ -162,20 +162,20 @@
 (defn- pack-image [picture]
   (let [prefix (if (re-find #"<Journal_URL>" (or (:picture/acknowledgement-template picture) ""))
                  (:paper/id (first (:picture/reference picture)))
-                 (:person/id (first (:picture/contact picture))))
-        [_ picture-name format-name] (re-matches #"(.+)\.(.+)" (:picture/name picture))]
-    (-> picture
-        (pack-obj)
-        (assoc :thumbnail
-               {:format (or format-name "")
-                :name (str prefix "/" (or picture-name (:picture/name picture)))
-                :class "/img-static/pictures"}
+                 (:person/id (first (:picture/contact picture))))]
+    (if-let [[_ picture-name format-name] (re-matches #"(.+)\.(.+)" (or (:picture/name picture) ""))]
+      (-> picture
+          (pack-obj)
+          (assoc :thumbnail
+                 {:format (or format-name "")
+                  :name (str prefix "/" (or picture-name (:picture/name picture)))
+                  :class "/img-static/pictures"}
 
-               :description
-               (if-let [expr-patterns (seq (:picture/expr-pattern picture))]
-                 (->> (map :expr-pattern/id expr-patterns)
-                      (str/join ", ")
-                      (str "curated pictures for ")))))))
+                 :description
+                 (if-let [expr-patterns (seq (:picture/expr-pattern picture))]
+                   (->> (map :expr-pattern/id expr-patterns)
+                        (str/join ", ")
+                        (str "curated pictures for "))))))))
 
 (defn- expression-table-row [db ontology-term-dbid relations]
   (let [ontology-term (d/entity db ontology-term-dbid)]

--- a/src/rest_api/formatters/object.clj
+++ b/src/rest_api/formatters/object.clj
@@ -25,10 +25,11 @@
   [class obj]
   (let [species-ident (keyword class "species")]
     (if-let [species (species-ident obj)]
-      (if-let [[_ g species] (re-matches #"(.).*[ _](.+)"
-                                         (:species/id species))]
-        (.toLowerCase (str g "_" species))
-        "unknown")
+      (if-let [species-id (:species/id species)]
+        (if-let [[_ g species] (re-matches #"(.).*[ _](.+)" species-id)]
+          (.toLowerCase (str g "_" species))
+          "unknown")
+        "all")
       "all")))
 
 (defmulti obj-label


### PR DESCRIPTION
Hotfix WormBase/website#5777 and WormBase/website#5741
caused by combination of: 
- missing :picture/name and 
- trying to pack :paper/species into taxonomy (which isn't a :species entity)

For testing:
http://dev.wormbase.org:9004/species/c_elegans/gene/WBGene00004804#01-9g-3
http://dev.wormbase.org:9004/species/c_elegans/gene/WBGene00000412#01-9g-3 