### PR TITLE
adding location widgets

### DIFF
--- a/src/rest_api/classes/cds.clj
+++ b/src/rest_api/classes/cds.clj
@@ -2,6 +2,7 @@
   (:require
     [rest-api.classes.gene.widgets.external-links :as external-links]
     ;[rest-api.classes.cds.widgets.overview :as overview]
+    [rest-api.classes.cds.widgets.location :as location]
     [rest-api.classes.cds.widgets.references :as references]
     [rest-api.routing :as routing]))
 
@@ -9,5 +10,6 @@
   {:entity-ns "cds"
    :widget
    {;:overview overview/widget not complete -  has some calculations that would need to be verified
+    :location location/widget
     :external_links external-links/widget
     :references references/widget}})

--- a/src/rest_api/classes/cds/widgets/location.clj
+++ b/src/rest_api/classes/cds/widgets/location.clj
@@ -1,19 +1,21 @@
-(ns rest-api.classes.gene.widgets.location
+(ns rest-api.classes.cds.widgets.location
   (:require
     [rest-api.classes.sequence.main :as sequence-fns]
     [rest-api.classes.generic-fields :as generic]))
 
-(defn tracks [gene]
-  {:data (if (:gene/corresponding-transposon gene)
-           ["TRANSPOSONS"
-            "TRANSPOSON_GENES"]
-           ["GENES"
-            "VARIATIONS_CLASSICAL_ALLELES"
-            "CLONES"])
+(defn tracks [cds]
+  {:data (when (= "Caenorhabditis elegans" (:species/id (:cds/species cds)))
+           (if (= "history" (:method/id (:locatable/method cds)))
+             ["HISTORICAL_GENES"]
+             ["GENES"
+              "TRANSPOSONS"
+              "TRANSPOSON_GENES"
+              "EST_BEST"
+              "PROTEIN_MOTIFS"]))
    :description "tracks displayed in GBrowse"})
 
-(defn genomic-image [gene]
-  {:data (sequence-fns/genomic-obj gene)
+(defn genomic-image [cds]
+  {:data (sequence-fns/genomic-obj cds)
    :description "The genomic location of the sequence to be displayed by GBrowse"})
 
 (def widget

--- a/src/rest_api/classes/clone.clj
+++ b/src/rest_api/classes/clone.clj
@@ -2,6 +2,7 @@
   (:require
     [rest-api.classes.gene.widgets.external-links :as external-links]
     ;[rest-api.classes.clone.widgets.overview :as overview]
+    [rest-api.classes.clone.widgets.location :as location]
     [rest-api.classes.clone.widgets.references :as references]
     [rest-api.routing :as routing]))
 
@@ -9,5 +10,6 @@
   {:entity-ns "clone"
    :widget
    {;:overview overview/widget; needs access to field not available in datomic schema
+    :location location/widget
     :external_links external-links/widget
     :references references/widget}})

--- a/src/rest_api/classes/clone/widgets/location.clj
+++ b/src/rest_api/classes/clone/widgets/location.clj
@@ -1,24 +1,21 @@
-(ns rest-api.classes.gene.widgets.location
+(ns rest-api.classes.clone.widgets.location
   (:require
     [rest-api.classes.sequence.main :as sequence-fns]
     [rest-api.classes.generic-fields :as generic]))
 
-(defn tracks [gene]
-  {:data (if (:gene/corresponding-transposon gene)
-           ["TRANSPOSONS"
-            "TRANSPOSON_GENES"]
-           ["GENES"
-            "VARIATIONS_CLASSICAL_ALLELES"
-            "CLONES"])
+(defn tracks [clone]
+  {:data ["GENES"
+          "CLONES"
+          "LINKS_AND_SUPERLINKS"
+          "GENOMIC_CANONICAL"]
    :description "tracks displayed in GBrowse"})
 
-(defn genomic-image [gene]
-  {:data (sequence-fns/genomic-obj gene)
+(defn genomic-image [clone]
+  {:data (sequence-fns/genomic-obj clone)
    :description "The genomic location of the sequence to be displayed by GBrowse"})
 
 (def widget
     {:name generic/name-field
-     :genetic_position generic/genetic-position
      :tracks tracks
      :genomic_position generic/genomic-position
      :genomic_image genomic-image})

--- a/src/rest_api/classes/expression_cluster/widgets/overview.clj
+++ b/src/rest_api/classes/expression_cluster/widgets/overview.clj
@@ -19,8 +19,7 @@
 	      (let [id-kw (first (filter #(= (name %) "id") (keys object)))]
 		{(let [i (id-kw object)]
 		   (if-let [result (re-find #":(\d+)_min" i)]
-		     (do (println (second result))
-			 (pad-zero (second result) 10)) i))
+			 (pad-zero (second result) 10)) i)
 		 (pack-obj object)}))))))
 
 (defn attribute-of [ec]

--- a/src/rest_api/classes/feature.clj
+++ b/src/rest_api/classes/feature.clj
@@ -1,9 +1,11 @@
 (ns rest-api.classes.feature
   (:require
     [rest-api.classes.feature.widgets.overview :as overview]
+    [rest-api.classes.feature.widgets.location :as location]
     [rest-api.routing :as routing]))
 
 (routing/defroutes
   {:entity-ns "feature"
    :widget
-   {:overview overview/widget}})
+   {:overview overview/widget
+    :location location/widget}})

--- a/src/rest_api/classes/feature/widgets/location.clj
+++ b/src/rest_api/classes/feature/widgets/location.clj
@@ -1,0 +1,35 @@
+(ns rest-api.classes.feature.widgets.location
+  (:require
+    [rest-api.classes.sequence.main :as sequence-fns]
+    [rest-api.classes.generic-fields :as generic]))
+
+(defn tracks [feature]
+  {:data ["GENES"
+          "RNASEQ_ASYMMETRIES"
+          "RNASEQ"
+          "RNASEQ_SPLICE"
+          "POLYSOMES"
+          "MICRO_ORF"
+          "DNASEI_HYPERSENSITIVE_SITE"
+          "REGULATORY_REGIONS"
+          "PROMOTER_REGIONS"
+          "HISTONE_BINDING_SITES"
+          "TRANSCRIPTION_FACTOR_BINDING_REGION"
+          "TRANSCRIPTION_FACTOR_BINDING_SITE"
+          "GENOME_SEQUENCE_ERROR_CORRECTED"
+          "BINDING_SITES_PREDICTED"
+          "BINDING_SITES_CURATED"
+          "BINDING_REGIONS"
+          "GENOME_SEQUENCE_ERROR"]
+   :description "tracks displayed in GBrowse"})
+
+(defn genomic-image [feature]
+  {:data (sequence-fns/genomic-obj feature)
+   :description "The genomic location of the sequence to be displayed by GBrowse"})
+
+(def widget
+    {:name generic/name-field
+     :genetic_position generic/genetic-position
+     :tracks tracks
+     :genomic_position generic/genomic-position
+     :genomic_image genomic-image})

--- a/src/rest_api/classes/generic_fields.clj
+++ b/src/rest_api/classes/generic_fields.clj
@@ -28,40 +28,59 @@
                                   (contains?
                                     object
                                     :variation/interpolated-map-position)))
-        [entity entity-role] (if variation-with-imp
-                               [(:variation.gene/gene (first (:variation/gene object))) "gene"]
-                               [object role])]
-    (let [[chr position error method] (let [kw-imp (keyword entity-role str-imp)
-                                            str-imp-component (str entity-role "." str-imp)
-                                            kw-map (keyword entity-role "map")
-                                            kw-map-map (keyword (str entity-role ".map") "map")
-                                            kw-imp-map (keyword str-imp-component "map")
-                                            kw-imp-position (keyword
-                                                              str-imp-component
-                                                              (if (= role "sequence") "float" "position"))]
-                                        (if
-                                          (or (= "sequence" entity-role)
-                                              (= "variation" entity-role)
-                                              (not (contains? entity kw-map)))
-                                          [(:map/id (kw-imp-map (kw-imp entity)))
-                                           (kw-imp-position (kw-imp entity))
-                                           nil
-                                           "interpolated"]
-                                          (let [map-position (:map-position/position (kw-map entity))]
-                                            [(:map/id (kw-map-map (kw-map entity)))
-                                             (:map-position.position/float map-position)
-                                             (:map-error/error map-position)
-                                             (if (= role entity-role) "" "interpolated")])))]
-      {:data [{:chromosome chr
-               :position position
-               :error error
-               :formatted (when (not-any? nil? [chr position])
-                            (if (nil? error)
-                              (format "%s:%2.2f +/- (unknown)f cM" chr position)
-                              (format "%s:%2.2f +/- %2.3f cM" chr position error)))
-               :method method}]
-       :db (:db/id entity)
-       :description (str "Genetic position of " role ": " (id-kw object))})))
+        [entities entity-role] (cond
+                                 variation-with-imp
+                                 [[(:variation.gene/gene
+                                     (first
+                                       (:variation/gene object)))]
+                                  "gene"]
+
+                                 (= role "protein")
+                                 (let [cdss (some->>
+                                              (:cds.corresponding-protein/_protein object)
+                                              (map :cds/_corresponding-protein))]
+                                   [(some->>
+                                      cdss
+                                      (filter #(not= "history" (:method/id (:locatable/method %))))
+                                      (map :gene.corresponding-cds/_cds)
+                                      first
+                                      (map :gene/_corresponding-cds))
+                                    "gene"])
+
+                                 :else
+                                 [[object] role])]
+    {:data
+       (not-empty
+        (for [entity entities
+              :let [[chr position error method]
+                     (let [kw-imp (keyword entity-role str-imp)
+                           str-imp-component (str entity-role "." str-imp)
+                           kw-map (keyword entity-role "map")
+                           kw-map-map (keyword (str entity-role ".map") "map")
+                           kw-imp-map (keyword str-imp-component "map")
+                           kw-imp-position (keyword
+                                             str-imp-component
+                                             (if (= role "sequence") "float" "position"))]
+                       (if
+                         (or (= "sequence" entity-role)
+                             (= "variation" entity-role)
+                             (not (contains? entity kw-map)))
+                         [(:map/id (kw-imp-map (kw-imp entity)))
+                          (kw-imp-position (kw-imp entity))
+                          nil
+                          "interpolated"]
+                         (let [map-position (:map-position/position (kw-map entity))]
+                           [(:map/id (kw-map-map (kw-map entity)))
+                            (:map-position.position/float map-position)
+                            (:map-error/error map-position)
+                            (if (= role entity-role) "" "interpolated")])))]]
+          {:chromosome chr
+           :position position
+           :error error
+           :formatted (when (not-any? nil? [chr position])
+                          (format "%s:%2.2f +/- %2.3f cM" chr position (or error (double 0))))
+           :method method}))
+     :description (str "Genetic position of " role ": " (id-kw object))}))
 
 (defn fusion-reporter [object]
   (let [id-kw (first (filter #(= (name %) "id") (keys object)))

--- a/src/rest_api/classes/generic_functions.clj
+++ b/src/rest_api/classes/generic_functions.clj
@@ -6,8 +6,10 @@
     "Transforms a `species-name` from the WB database into
       a name used to look up connection configuration to a sequence db."
         [species]
+        (do (println species)
+            
           (let  [species-name-parts (str/split species #" ")
                           g  (str/lower-case  (ffirst species-name-parts))
                                    species  (second species-name-parts)]
-                (str/join "_"  [g species])))
+                (str/join "_"  [g species]))))
 

--- a/src/rest_api/classes/generic_functions.clj
+++ b/src/rest_api/classes/generic_functions.clj
@@ -3,13 +3,11 @@
     [clojure.string :as str]))
 
 (defn xform-species-name
-    "Transforms a `species-name` from the WB database into
-      a name used to look up connection configuration to a sequence db."
-        [species]
-        (do (println species)
-            
-          (let  [species-name-parts (str/split species #" ")
-                          g  (str/lower-case  (ffirst species-name-parts))
-                                   species  (second species-name-parts)]
-                (str/join "_"  [g species]))))
+  "Transforms a `species-name` from the WB database into
+  a name used to look up connection configuration to a sequence db."
+  [species]
+  (let  [species-name-parts (str/split species #" ")
+         g  (str/lower-case  (ffirst species-name-parts))
+         species  (second species-name-parts)]
+    (str/join "_"  [g species])))
 

--- a/src/rest_api/classes/operon.clj
+++ b/src/rest_api/classes/operon.clj
@@ -1,6 +1,7 @@
 (ns rest-api.classes.operon
   (:require
     [rest-api.classes.operon.widgets.overview :as overview]
+    [rest-api.classes.operon.widgets.location :as location]
     [rest-api.classes.operon.widgets.references :as references]
     [rest-api.routing :as routing]))
 
@@ -8,4 +9,5 @@
   {:entity-ns "operon"
    :widget
    {:overview overview/widget
+    :location location/widget
     :references references/widget}})

--- a/src/rest_api/classes/operon/widgets/location.clj
+++ b/src/rest_api/classes/operon/widgets/location.clj
@@ -1,19 +1,15 @@
-(ns rest-api.classes.gene.widgets.location
+(ns rest-api.classes.operon.widgets.location
   (:require
     [rest-api.classes.sequence.main :as sequence-fns]
     [rest-api.classes.generic-fields :as generic]))
 
-(defn tracks [gene]
-  {:data (if (:gene/corresponding-transposon gene)
-           ["TRANSPOSONS"
-            "TRANSPOSON_GENES"]
-           ["GENES"
-            "VARIATIONS_CLASSICAL_ALLELES"
-            "CLONES"])
+(defn tracks [operon]
+  {:data ["GENES"
+          "OPERONS"]
    :description "tracks displayed in GBrowse"})
 
-(defn genomic-image [gene]
-  {:data (sequence-fns/genomic-obj gene)
+(defn genomic-image [operon]
+  {:data (sequence-fns/genomic-obj operon)
    :description "The genomic location of the sequence to be displayed by GBrowse"})
 
 (def widget

--- a/src/rest_api/classes/pcr_product.clj
+++ b/src/rest_api/classes/pcr_product.clj
@@ -1,10 +1,13 @@
 (ns rest-api.classes.pcr-product
   (:require
     [rest-api.classes.pcr-product.widgets.overview :as overview]
+    ;[rest-api.classes.pcr-product.widgets.location :as location]
     [rest-api.routing :as routing]))
 
 (routing/defroutes
   {:entity-ns "pcr-product"
    :uri-name "pcr_oligo"
    :widget
-   {:overview overview/widget}})
+   {:overview overview/widget
+    ;:location location/widget
+    }})

--- a/src/rest_api/classes/pcr_product/widgets/location.clj
+++ b/src/rest_api/classes/pcr_product/widgets/location.clj
@@ -1,19 +1,18 @@
-(ns rest-api.classes.gene.widgets.location
+(ns rest-api.classes.pcr-product.widgets.location
   (:require
     [rest-api.classes.sequence.main :as sequence-fns]
     [rest-api.classes.generic-fields :as generic]))
 
-(defn tracks [gene]
-  {:data (if (:gene/corresponding-transposon gene)
-           ["TRANSPOSONS"
-            "TRANSPOSON_GENES"]
-           ["GENES"
-            "VARIATIONS_CLASSICAL_ALLELES"
-            "CLONES"])
+(defn tracks [pcr-product]
+  {:data ["GENES"
+          "MICROARRAY_OLIGO_PROBES"
+          "PCR_PRODUCTS"
+          "ORFEOME_PCR_PRODUCTS"
+          "CLONES"]
    :description "tracks displayed in GBrowse"})
 
-(defn genomic-image [gene]
-  {:data (sequence-fns/genomic-obj gene)
+(defn genomic-image [pcr-product]
+  {:data (sequence-fns/genomic-obj pcr-product)
    :description "The genomic location of the sequence to be displayed by GBrowse"})
 
 (def widget

--- a/src/rest_api/classes/protein.clj
+++ b/src/rest_api/classes/protein.clj
@@ -2,10 +2,12 @@
   (:require
     [rest-api.classes.gene.widgets.external-links :as external-links]
     ;[rest-api.classes.protein.widgets.overview :as overview]
+    [rest-api.classes.protein.widgets.location :as location]
     [rest-api.routing :as routing]))
 
 (routing/defroutes
   {:entity-ns "protein"
    :widget
    {;:overview overview/widget
+    :location location/widget
     :external_links external-links/widget}})

--- a/src/rest_api/classes/protein/widgets/location.clj
+++ b/src/rest_api/classes/protein/widgets/location.clj
@@ -1,19 +1,15 @@
-(ns rest-api.classes.gene.widgets.location
+(ns rest-api.classes.protein.widgets.location
   (:require
     [rest-api.classes.sequence.main :as sequence-fns]
     [rest-api.classes.generic-fields :as generic]))
 
-(defn tracks [gene]
-  {:data (if (:gene/corresponding-transposon gene)
-           ["TRANSPOSONS"
-            "TRANSPOSON_GENES"]
-           ["GENES"
-            "VARIATIONS_CLASSICAL_ALLELES"
-            "CLONES"])
+(defn tracks [protein]
+  {:data ["GENES"
+          "PROTEIN_MOTIFS"]
    :description "tracks displayed in GBrowse"})
 
-(defn genomic-image [gene]
-  {:data (sequence-fns/genomic-obj gene)
+(defn genomic-image [protein]
+  {:data (sequence-fns/genomic-obj protein)
    :description "The genomic location of the sequence to be displayed by GBrowse"})
 
 (def widget

--- a/src/rest_api/classes/pseudogene.clj
+++ b/src/rest_api/classes/pseudogene.clj
@@ -1,10 +1,11 @@
 (ns rest-api.classes.pseudogene
   (:require
     [rest-api.classes.pseudogene.widgets.overview :as overview]
+    [rest-api.classes.pseudogene.widgets.location :as location]
     [rest-api.routing :as routing]))
 
 (routing/defroutes
   {:entity-ns "pseudogene"
    :widget
    {:overview overview/widget
-    }})
+    :location location/widget}})

--- a/src/rest_api/classes/pseudogene/widgets/location.clj
+++ b/src/rest_api/classes/pseudogene/widgets/location.clj
@@ -1,19 +1,15 @@
-(ns rest-api.classes.gene.widgets.location
+(ns rest-api.classes.pseudogene.widgets.location
   (:require
     [rest-api.classes.sequence.main :as sequence-fns]
     [rest-api.classes.generic-fields :as generic]))
 
-(defn tracks [gene]
-  {:data (if (:gene/corresponding-transposon gene)
-           ["TRANSPOSONS"
-            "TRANSPOSON_GENES"]
-           ["GENES"
-            "VARIATIONS_CLASSICAL_ALLELES"
-            "CLONES"])
+(defn tracks [pseudogene]
+  {:data (when (= "Caenorhabditis elegans" (:species/id (:pseudogene/species pseudogene)))
+             ["GENES"])
    :description "tracks displayed in GBrowse"})
 
-(defn genomic-image [gene]
-  {:data (sequence-fns/genomic-obj gene)
+(defn genomic-image [pseudogene]
+  {:data (sequence-fns/genomic-obj pseudogene)
    :description "The genomic location of the sequence to be displayed by GBrowse"})
 
 (def widget

--- a/src/rest_api/classes/sequence.clj
+++ b/src/rest_api/classes/sequence.clj
@@ -2,6 +2,7 @@
   (:require
     [rest-api.classes.gene.widgets.external-links :as external-links]
     ;[rest-api.classes.sequence.widgets.overview :as overview]
+    [rest-api.classes.sequence.widgets.location :as location]
     [rest-api.classes.sequence.widgets.references :as references]
     [rest-api.routing :as routing]))
 
@@ -10,4 +11,5 @@
    :widget
    {;:overview overview/widget
     :external_links external-links/widget
+    :location location/widget
     :references references/widget}})

--- a/src/rest_api/classes/sequence/main.clj
+++ b/src/rest_api/classes/sequence/main.clj
@@ -66,9 +66,8 @@
       tracks)))
 
 (defn genomic-obj [object]
-  (do (println (keys object))
   (when-let [segment (get-longest-segment object)]
     (let [[start stop] (->> segment
                              ((juxt :start :end))
                              (sort-by +))]
-      (create-genomic-location-obj start stop object segment nil true)))))
+      (create-genomic-location-obj start stop object segment nil true))))

--- a/src/rest_api/classes/sequence/main.clj
+++ b/src/rest_api/classes/sequence/main.clj
@@ -66,8 +66,9 @@
       tracks)))
 
 (defn genomic-obj [object]
+  (do (println (keys object))
   (when-let [segment (get-longest-segment object)]
     (let [[start stop] (->> segment
                              ((juxt :start :end))
                              (sort-by +))]
-      (create-genomic-location-obj start stop object segment nil true))))
+      (create-genomic-location-obj start stop object segment nil true)))))

--- a/src/rest_api/classes/sequence/widgets/location.clj
+++ b/src/rest_api/classes/sequence/widgets/location.clj
@@ -1,0 +1,21 @@
+(ns rest-api.classes.sequence.widgets.location
+  (:require
+    [rest-api.classes.sequence.main :as sequence-fns]
+    [rest-api.classes.generic-fields :as generic]))
+
+(defn tracks [s]
+  {:data (when (= "Caenorhabditis elegans" (:species/id (:sequence/species s)))
+           ["GENES"
+            "EST_BEST"])
+   :description "tracks displayed in GBrowse"})
+
+(defn genomic-image [s]
+  {:data (sequence-fns/genomic-obj s)
+   :description "The genomic sequence of the sequence to be displayed by GBrowse"})
+
+(def widget
+    {:name generic/name-field
+     :genetic_position generic/genetic-position
+     :tracks tracks
+     :genomic_position generic/genomic-position
+     :genomic_image genomic-image})

--- a/src/rest_api/classes/transcript.clj
+++ b/src/rest_api/classes/transcript.clj
@@ -2,6 +2,7 @@
   (:require
    [rest-api.classes.gene.widgets.external-links :as external-links]
    ;[rest-api.classes.transcript.widgets.overview :as overview]
+   [rest-api.classes.transcript.widgets.location :as location]
    [rest-api.classes.transcript.widgets.references :as references]
    [rest-api.classes.gene.expression :as exp]
    [rest-api.formatters.object :as obj]
@@ -35,6 +36,7 @@
    {;:overview overview/widget
     :expression expression-widget
     :external_links external-links/widget
+    :location location/widget
     :references references/widget}
    :field
    {:fpkm_expression_summary_ls exp/fpkm-expression-summary-ls}})

--- a/src/rest_api/classes/transcript/widgets/location.clj
+++ b/src/rest_api/classes/transcript/widgets/location.clj
@@ -1,19 +1,16 @@
-(ns rest-api.classes.gene.widgets.location
+(ns rest-api.classes.transcript.widgets.location
   (:require
     [rest-api.classes.sequence.main :as sequence-fns]
     [rest-api.classes.generic-fields :as generic]))
 
-(defn tracks [gene]
-  {:data (if (:gene/corresponding-transposon gene)
-           ["TRANSPOSONS"
-            "TRANSPOSON_GENES"]
+(defn tracks [transcript]
+  {:data (when (= "Caenorhabditis elegans" (:species/id (:transcript/species transcript)))
            ["GENES"
-            "VARIATIONS_CLASSICAL_ALLELES"
-            "CLONES"])
+            "EST_BEST"])
    :description "tracks displayed in GBrowse"})
 
-(defn genomic-image [gene]
-  {:data (sequence-fns/genomic-obj gene)
+(defn genomic-image [transcript]
+  {:data (sequence-fns/genomic-obj transcript)
    :description "The genomic location of the sequence to be displayed by GBrowse"})
 
 (def widget

--- a/src/rest_api/classes/transposon.clj
+++ b/src/rest_api/classes/transposon.clj
@@ -1,9 +1,11 @@
 (ns rest-api.classes.transposon
   (:require
     [rest-api.classes.transposon.widgets.overview :as overview]
+    [rest-api.classes.transposon.widgets.location :as location]
     [rest-api.routing :as routing]))
 
 (routing/defroutes
   {:entity-ns "transposon"
    :widget
-   {:overview overview/widget}})
+   {:overview overview/widget
+    :location location/widget}})

--- a/src/rest_api/classes/transposon/widgets/location.clj
+++ b/src/rest_api/classes/transposon/widgets/location.clj
@@ -1,19 +1,15 @@
-(ns rest-api.classes.gene.widgets.location
+(ns rest-api.classes.transposon.widgets.location
   (:require
     [rest-api.classes.sequence.main :as sequence-fns]
     [rest-api.classes.generic-fields :as generic]))
 
-(defn tracks [gene]
-  {:data (if (:gene/corresponding-transposon gene)
-           ["TRANSPOSONS"
-            "TRANSPOSON_GENES"]
-           ["GENES"
-            "VARIATIONS_CLASSICAL_ALLELES"
-            "CLONES"])
+(defn tracks [transposon]
+  {:data ["TRANSPOSON_GENES"
+          "TRANSPOSONS"]
    :description "tracks displayed in GBrowse"})
 
-(defn genomic-image [gene]
-  {:data (sequence-fns/genomic-obj gene)
+(defn genomic-image [transposon]
+  {:data (sequence-fns/genomic-obj transposon)
    :description "The genomic location of the sequence to be displayed by GBrowse"})
 
 (def widget

--- a/src/rest_api/classes/variation.clj
+++ b/src/rest_api/classes/variation.clj
@@ -2,6 +2,7 @@
   (:require
     [rest-api.classes.variation.widgets.overview :as overview]
     [rest-api.classes.variation.widgets.phenotypes :as phenotypes]
+    [rest-api.classes.variation.widgets.location :as location]
     [rest-api.classes.gene.widgets.external-links :as external-links]
     [rest-api.classes.gene.widgets.references :as references]
     [rest-api.routing :as routing]))
@@ -12,4 +13,5 @@
    {:overview overview/widget
     :phenotypes phenotypes/widget
     :external_links external-links/widget
+    :location location/widget
     :references references/widget}})

--- a/src/rest_api/classes/variation/widgets/location.clj
+++ b/src/rest_api/classes/variation/widgets/location.clj
@@ -1,0 +1,37 @@
+(ns rest-api.classes.variation.widgets.location
+  (:require
+    [rest-api.classes.sequence.main :as sequence-fns]
+    [rest-api.classes.generic-fields :as generic]))
+
+(defn tracks [variation]
+  {:data (cond
+           (= "Caenorhabditis elegans"
+              (:species/id (:variation/species variation)))
+           ["GENES"
+            "VARIATIONS_CLASSICAL_ALLELES"
+            "VARIATIONS_HIGH_THROUGHPUT_ALLELES"
+            "VARIATIONS_POLYMORPHISMS"
+            "VARIATIONS_CHANGE_OF_FUNCTION_ALLELES"
+            "VARIATIONS_CHANGE_OF_FUNCTION_POLYMORPHISMS"
+            "VARIATIONS_TRANSPOSON_INSERTION_SITES"
+            "VARIATIONS_MILLION_MUTATION_PROJECT"]
+
+           (= "Caenorhabditis briggsae"
+              (:species/id (:variation/species variation)))
+           ["GENES"
+            "VARIATIONS_POLYMORPHISMS"]
+
+           :else
+           ["GENES"])
+   :description "tracks displayed in GBrowse"})
+
+(defn genomic-image [variation]
+  {:data (sequence-fns/genomic-obj variation)
+   :description "The genomic location of the sequence to be displayed by GBrowse"})
+
+(def widget
+    {:name generic/name-field
+     :genetic_position generic/genetic-position
+     :tracks tracks
+     :genomic_position generic/genomic-position
+     :genomic_image genomic-image})


### PR DESCRIPTION
This pull request contains location widgets for:
- cds
- clone
- feature
- operon
- pcr_product (commented out)
- protein
- pseudogene
- sequence
- transcript
- transposon
- variation

The pcr_product widget is not being released because I noticed and error when running the following command:

```bash
curl -g -H content-type:application/json http://localhost:8130/rest/widget/pcr_oligo/cenix:10-a2/location | jq '.
```
Basically my code requires the species field but for this entity it was not available. 

I realise that for protein there still requires some work. I will be doing one more pass through tomorrow