### PR TITLE
Migrate ACeDB dependency of BLAST result to d2c

### DIFF
--- a/src/rest_api/classes/blast_hit.clj
+++ b/src/rest_api/classes/blast_hit.clj
@@ -41,15 +41,6 @@
      :protein (pack-obj "protein" protein :label "[Protein Summary]")
      :sequence (pack-obj cds)}))
 
-;; est
-(defmethod convert-entity :sequence/id [sequence]
-  (let [gene (some->> sequence
-                      (:locatable/_parent)
-                      (filter :gene/id)
-                      (first))]
-    {:corresponding_gene (pack-obj "gene" gene :label "[Corr. Gene]")
-     :sequence (pack-obj sequence)}))
-
 (defmethod convert-entity :default [entity]
   {:sequence (pack-obj entity)})
 

--- a/src/rest_api/classes/blast_hit.clj
+++ b/src/rest_api/classes/blast_hit.clj
@@ -13,6 +13,7 @@
   (fn [entity]
     (first (filter (partial contains? entity) id-types))))
 
+;; wormpep
 (defmethod convert-entity :transcript/id [entity]
   (let [transcript entity
         protein (some->> transcript
@@ -28,6 +29,7 @@
      :protein (pack-obj "protein" protein :label "[Protein Summary]")
      :sequence (pack-obj transcript)}))
 
+;; wormpep
 (defmethod convert-entity :cds/id [entity]
   (let [cds entity
         protein (some->> cds
@@ -41,6 +43,7 @@
      :protein (pack-obj "protein" protein :label "[Protein Summary]")
      :sequence (pack-obj cds)}))
 
+;; est
 (defmethod convert-entity :sequence/id [entity]
   (let [sequence entity
         gene (some->> sequence

--- a/src/rest_api/classes/blast_hit.clj
+++ b/src/rest_api/classes/blast_hit.clj
@@ -69,5 +69,5 @@
 (def routes
   [(sweet/GET "/convert/:id" []
               :path-params [id :- (sweet/describe schema/Str "WB ID of a BLAST hit")]
-;;              :no-doc true
+              :no-doc true
               (response/ok (convert-id id)))])

--- a/src/rest_api/classes/blast_hit.clj
+++ b/src/rest_api/classes/blast_hit.clj
@@ -14,9 +14,8 @@
     (first (filter (partial contains? entity) id-types))))
 
 ;; wormpep
-(defmethod convert-entity :transcript/id [entity]
-  (let [transcript entity
-        protein (some->> transcript
+(defmethod convert-entity :transcript/id [transcript]
+  (let [protein (some->> transcript
                          (:transcript/corresponding-cds)
                          (:transcript.corresponding-cds/cds)
                          (:cds/corresponding-protein)
@@ -30,9 +29,8 @@
      :sequence (pack-obj transcript)}))
 
 ;; wormpep
-(defmethod convert-entity :cds/id [entity]
-  (let [cds entity
-        protein (some->> cds
+(defmethod convert-entity :cds/id [cds]
+  (let [protein (some->> cds
                          (:cds/corresponding-protein)
                          (:cds.corresponding-protein/protein))
         gene (some->> cds
@@ -44,9 +42,8 @@
      :sequence (pack-obj cds)}))
 
 ;; est
-(defmethod convert-entity :sequence/id [entity]
-  (let [sequence entity
-        gene (some->> sequence
+(defmethod convert-entity :sequence/id [sequence]
+  (let [gene (some->> sequence
                       (:locatable/_parent)
                       (filter :gene/id)
                       (first))]

--- a/src/rest_api/classes/blast_hit.clj
+++ b/src/rest_api/classes/blast_hit.clj
@@ -31,7 +31,19 @@
      :sequence (pack-obj transcript)}))
 
 (defmethod convert-id :cds/id [id]
-  )
+  (let [db (d/db datomic-conn)
+        cds (d/entity db [:cds/id id])
+        protein (some->> cds
+                         (:cds/corresponding-protein)
+                         (:cds.corresponding-protein/protein))
+        gene (some->> cds
+                      (:gene.corresponding-cds/_cds)
+                      (first)
+                      (:gene/_corresponding-cds))]
+    (prn gene)
+    {:gene (pack-obj "gene" gene :label "[Gene Summary]")
+     :protein (pack-obj "protein" protein :label "[Protein Summary]")
+     :sequence (pack-obj cds)}))
 
 (def routes
   [(sweet/GET "/convert/:id" []

--- a/src/rest_api/classes/blast_hit.clj
+++ b/src/rest_api/classes/blast_hit.clj
@@ -1,0 +1,32 @@
+(ns rest-api.classes.blast-hit
+  (:require
+   [compojure.api.sweet :as sweet]
+   [datomic.api :as d]
+   [rest-api.db.main :refer [datomic-conn]]
+   [rest-api.formatters.object :as obj :refer [pack-obj]]
+   [ring.util.http-response :as response]
+   [schema.core :as schema]))
+
+
+(defn- convert-id [id]
+  (let [db (d/db datomic-conn)]
+    (or (if-let [transcript (d/entity db [:transcript/id id])]
+          (let [protein (some->> transcript
+                                 (:transcript/corresponding-cds)
+                                 (:transcript.corresponding-cds/cds)
+                                 (:cds/corresponding-protein)
+                                 (:cds.corresponding-protein/protein))
+                gene (some->> transcript
+                              (:gene.corresponding-transcript/_transcript)
+                              (first)
+                              (:gene/_corresponding-transcript))]
+            {:gene (pack-obj "gene" gene :label "[Gene Summary]")
+             :protein (pack-obj "protein" protein :label "[Protein Summary]")
+             :sequence (pack-obj transcript)}))
+        )))
+
+(def routes
+  [(sweet/GET "/convert/:id" []
+              :path-params [id :- (sweet/describe schema/Str "WB ID of a BLAST hit")]
+;;              :no-doc true
+              (response/ok (convert-id id)))])

--- a/src/rest_api/classes/blast_hit.clj
+++ b/src/rest_api/classes/blast_hit.clj
@@ -42,7 +42,6 @@
                       (:gene.corresponding-cds/_cds)
                       (first)
                       (:gene/_corresponding-cds))]
-    (prn gene)
     {:gene (pack-obj "gene" gene :label "[Gene Summary]")
      :protein (pack-obj "protein" protein :label "[Protein Summary]")
      :sequence (pack-obj cds)}))

--- a/src/rest_api/main.clj
+++ b/src/rest_api/main.clj
@@ -9,6 +9,7 @@
    [rest-api.classes.analysis :as analysis]
    [rest-api.classes.anatomy-term :as anatomy-term]
    [rest-api.classes.antibody :as antibody]
+   [rest-api.classes.blast-hit :as blast-hit]
    [rest-api.classes.cds :as cds]
    [rest-api.classes.clone :as clone]
    [rest-api.classes.construct :as construct]
@@ -53,6 +54,7 @@
   [analysis/routes
    anatomy-term/routes
    antibody/routes
+   blast-hit/routes
    cds/routes
    clone/routes
    construct/routes


### PR DESCRIPTION
Objective: remove ACeDB dependency from formatting of BLAST result

IDs of BLAST hits need to be converted to the `pack-obj`format of their corresponding gene and protein for display. Catalyst app currently relies on ACeDB for this conversion, resulting in frequent crash of BLAST service. https://github.com/WormBase/website/blob/master/lib/WormBase/API/Service/blast_blat.pm#L709-L727

Solution:  create an additional endpoint for ID conversion in the d2c repo

Technical details:
- additional route `/rest/convert/:id` is added to `ns rest-api.classes.blast-hit`
- multimethod is used to handle IDs of different types (like :protein/id vs :transcript/id).

Thanks!

