### PR TITLE
Created transposon and motif widges for transposon family page

### DIFF
--- a/src/rest_api/classes/transposon_family.clj
+++ b/src/rest_api/classes/transposon_family.clj
@@ -1,9 +1,13 @@
 (ns rest-api.classes.transposon-family
   (:require
     [rest-api.classes.transposon-family.widgets.overview :as overview]
+    [rest-api.classes.transposon-family.widgets.transposons :as transposons]
+    [rest-api.classes.transposon-family.widgets.motifs :as motifs]
     [rest-api.routing :as routing]))
 
 (routing/defroutes
   {:entity-ns "transposon-family"
    :widget
-   {:overview overview/widget}})
+   {:overview overview/widget
+    :transposons transposons/widget
+    :motifs motifs/widget}})

--- a/src/rest_api/classes/transposon_family/widgets/motifs.clj
+++ b/src/rest_api/classes/transposon_family/widgets/motifs.clj
@@ -1,0 +1,14 @@
+(ns rest-api.classes.transposon-family.widgets.motifs
+  (:require
+   [rest-api.classes.generic-fields :as generic]
+   [rest-api.formatters.object :as obj :refer  [pack-obj]]))
+
+(defn motifs [tf]
+  {:data (when-let [ms (:transposon-family/associated-motif tf)]
+           (for [m ms]
+             (pack-obj m)))
+   :description "Motifs attached to this record"})
+
+(def widget
+  {:name generic/name-field
+   :motifs motifs})

--- a/src/rest_api/classes/transposon_family/widgets/transposons.clj
+++ b/src/rest_api/classes/transposon_family/widgets/transposons.clj
@@ -1,0 +1,18 @@
+(ns rest-api.classes.transposon-family.widgets.transposons
+  (:require
+    [clojure.string :as str]
+    [rest-api.classes.generic-fields :as generic]
+    [rest-api.formatters.object :as obj :refer  [pack-obj]]))
+
+(defn family-members [tf]
+  {:data (when-let [transposons (:transposon/_member-of tf)]
+           (for [transposon transposons]
+             {:copy_status (when-let [status-kw (:transposon.copy-status/status
+                                                  (:transposon/copy-status transposon))]
+                             (str/capitalize (str (name status-kw))))
+              :id (pack-obj transposon)}))
+   :description "Transposon members of this family"})
+
+(def widget
+  {:name generic/name-field
+   :family_members family-members})


### PR DESCRIPTION
In this pull request I have made the last two widgets for transposon-family. 

- transposons
- motifs

This was relatively simple to create. I don't anticipate too many problems. The one concern I have is that for the motifs widget the Ace API produces a single motif (not array). I don't know of a case where there would be more than one but it is more than logical to believe that it should be an array of results. I am not sure if this will break the template. But I think the template will need to be changed to handle the array if need be. 
