### PR TITLE
Contains and origin widgets for stain page

### DIFF
--- a/src/rest_api/classes/gene/variation.clj
+++ b/src/rest_api/classes/gene/variation.clj
@@ -2,171 +2,7 @@
   (:require
    [clojure.string :as str]
    [datomic.api :as d]
-   [pseudoace.utils :as pace-utils]
-   [rest-api.formatters.object :refer [pack-obj]]))
-
-(def ^{:private true} molecular-change-effects
-  {:molecular-change/missense "Missense"
-   :molecular-change/nonsense "Nonsense"
-   :molecular-change/frameshift "Frameshift"
-   :molecular-change/silent "Silent"
-   :molecular-change/splice-site "Splice site"
-   :molecular-change/promoter "Promoter"
-   :molecular-change/genomic-neighbourhood "Genomic neighbourhood"
-   :molecular-change/regulatory-feature "Regulatory feature"
-   :molecular-change/readthrough "Readthrough"})
-
-(def ^{:private true} molecular-change-kinds
-  {:molecular-change/intron "Intron"
-   :molecular-change/coding-exon "Coding exon"
-   :molecular-change/utr-5 "5' UTR"
-   :molecular-change/utr-3 "3' UTR"})
-
-(defn- process-aa-change [molecular-change]
-  (pace-utils/cond-let
-   [n]
-   (first (:molecular-change/missense molecular-change))
-   (:molecular-change.missense/text n)
-
-   (:molecular-change/nonsense molecular-change)
-   (:molecular-change.nonsense/text n)))
-
-(defn- process-aa-position [molecular-change]
-  (pace-utils/cond-let
-   [n]
-   (first (:molecular-change/missense molecular-change))
-   (:molecular-change.missense/int n)
-
-   (:molecular-change/nonsense molecular-change)
-   (nth (re-find #"\((\d+)\)"
-                 (:molecular-change.nonsense/text n)) 1)))
-
-(defn- process-aa-composite [molecular-change]
-  (let [change (process-aa-change molecular-change)
-        position (process-aa-position molecular-change)]
-    (if (and change position)
-      (let [change-parts (str/split change #"\s+")]
-        (->>
-         [(first change-parts) position (nth change-parts 2)]
-         (map str/capitalize)
-         (str/join ""))))))
-
-(defn- change-set
-  "Return a the set of keys of all maps in `change-map-seqs`."
-  [& change-map-seqs]
-  (->> (apply concat change-map-seqs)
-       (mapcat keys)
-       (set)))
-
-;; TODO: split up and refactor this function.
-(defn process-variation [var & {:keys [window]
-                                 :or {window 20}}]
-  (let [slice (comp seq (partial take 20))
-        cds-changes (slice (:variation/predicted-cds var))
-        trans-changes (slice (:variation/transcript var))
-        gene-changes (slice (:variation/gene var))]
-    (pace-utils/vmap
-     :variation
-     (pack-obj "variation" var)
-
-     :type
-     (if (:variation/transposon-insertion var)
-       "transposon insertion"
-       (str/join ", "
-                 (or
-                  (pace-utils/those
-                   (if (:variation/engineered-allele var)
-                     "Engineered allele")
-                   (if (:variation/allele var)
-                     "Allele")
-                   (if (:variation/snp var)
-                     "SNP")
-                   (if (:variation/confirmed-snp var)
-                     "Confirmed SNP")
-                   (if (:variation/predicted-snp var)
-                     "Predicted SNP")
-                   (if (:variation/reference-strain-digest var)
-                     "RFLP"))
-                  ["unknown"])))
-
-     :method_name
-     (if-let [method (:variation/method var)]
-       (format "<a class=\"longtext\" tip=\"%s\">%s</a>"
-               (or (:method.remark/text
-                    (first (:method/remark methods)))
-                   "")
-               (str/replace (:method/id method) #"_" " ")))
-
-     ;; don't populate since we're coming from gene...
-     :gene nil
-     
-     :molecular_change
-     (cond
-       (:variation/substitution var)
-       "Substitution"
-
-       (:variation/insertion var)
-       "Insertion"
-
-       (:variation/deletion var)
-       "Deletion"
-
-       (:variation/inversion var)
-       "Inversion"
-
-       (:variation/tandem-duplication var)
-       "Tandem_duplication"
-
-       :default
-       "Not curated")
-     :locations
-     (let [changes (change-set cds-changes gene-changes trans-changes)]
-       (->> (map molecular-change-kinds changes)
-            (filter identity)))
-     :effects
-     (let [changes (change-set cds-changes gene-changes trans-changes)]
-       (->> changes
-            (map molecular-change-effects)
-            (filter identity)
-            (not-empty)))
-     :aa_change
-     (->> (map process-aa-change cds-changes)
-          (filter identity)
-          (not-empty))
-     :aa_position
-     (->> (map process-aa-position cds-changes)
-          (filter identity)
-          (not-empty))
-     :composite_change
-     (->> (map process-aa-composite cds-changes)
-          (filter identity)
-          (not-empty))
-     :isoform
-     (->> (for [cc cds-changes
-                :when (or (:molecular-change/missense cc)
-                          (:molecular-change/nonsense cc))]
-            (pack-obj "cds" (:variation.predicted-cds/cds cc)))
-          (seq)
-          (not-empty))
-     :phen_count
-     (count (:variation/phenotype var))
-     :strain
-     (->> (:variation/strain var)
-          (map :variation.strain/strain)
-          (map #(pack-obj "strain" %))
-          (not-empty))
-     :sources
-     (let [var-refs (:variation/reference var)
-           sources (if (empty? var-refs)
-                     (map #(let [packed (pack-obj %)]
-                             (into packed
-                                   {:label
-                                    (str/replace (:label packed)
-                                                 #"_" " ")}))
-                          (:variation/analysis var))
-                     (map #(pack-obj (:variation.reference/paper %))
-                          var-refs))]
-           (not-empty sources)))))
+   [rest-api.classes.variation.core :as variation-core]))
 
 (defn alleles [gene]
   (let [db (d/entity-db gene)]
@@ -177,7 +13,7 @@
                        [?var :variation/gene ?vh]
                        [?var :variation/phenotype _]]
                      db (:db/id gene))
-                (map #(process-variation (d/entity db %))))
+                (map #(variation-core/process-variation (d/entity db %))))
      :description
      "alleles and polymorphisms with associated phenotype"}))
 
@@ -216,7 +52,7 @@
                  [?var :variation/allele _]
                  (not [?var :variation/phenotype _])]
                db (:db/id gene))
-          (map #(process-variation (d/entity db %))))
+          (map #(variation-core/process-variation (d/entity db %))))
      :description "alleles currently with no associated phenotype"}))
 
 (defn polymorphisms [gene]
@@ -230,6 +66,6 @@
                  (not [?var :variation/allele _])
                  (not [?var :variation/phenotype _])]
                db (:db/id gene))
-          (map #(process-variation (d/entity db %))))
+          (map #(variation-core/process-variation (d/entity db %))))
      :description (str "polymorphisms and natural variations "
                        "currently with no associated phenotype")}))

--- a/src/rest_api/classes/generic_fields.clj
+++ b/src/rest_api/classes/generic_fields.clj
@@ -169,7 +169,11 @@
              (not-empty
                (remove
                  nil?
-                 (for [lab labs]
+                 (for [l labs
+                       :let [kw-lab (keyword (str role ".location") "laboratory")
+                             lab (if (contains? l kw-lab)
+                                   (kw-lab l)
+                                   l)]]
                    (when-let [laboratory (pack-obj lab)]
                      {:laboratory laboratory
                       :representative (when-let [reps (:laboratory/representative lab)]

--- a/src/rest_api/classes/strain.clj
+++ b/src/rest_api/classes/strain.clj
@@ -2,6 +2,8 @@
   (:require
     [rest-api.classes.strain.widgets.phenotypes :as phenotypes]
     [rest-api.classes.strain.widgets.overview :as overview]
+    [rest-api.classes.strain.widgets.contains :as contains]
+    [rest-api.classes.strain.widgets.origin :as origin]
     [rest-api.classes.strain.widgets.references :as references]
     [rest-api.routing :as routing]))
 
@@ -9,5 +11,7 @@
   {:entity-ns "strain"
    :widget
    {:overview overview/widget
+    :contains contains/widget
+    :origin origin/widget
     :phenotypes phenotypes/widget
     :references references/widget}})

--- a/src/rest_api/classes/strain/widgets/contains.clj
+++ b/src/rest_api/classes/strain/widgets/contains.clj
@@ -1,0 +1,40 @@
+(ns rest-api.classes.strain.widgets.contains
+  (:require
+   [rest-api.classes.generic-fields :as generic]
+   [rest-api.classes.variation.core :as variation-core]
+   [rest-api.formatters.object :as obj :refer [pack-obj]]))
+
+(defn rearrangements [s]
+  {:data (when-let [rs (:rearrangement/_strain s)]
+           (map pack-obj rs))
+   :description "rearrangements contained in the strain"})
+
+(defn clones [s]
+  {:data (when-let [clones (:clone/_in-strain s)]
+           (map pack-obj clones))
+   :description "clones contained in the strain"})
+
+(defn alleles [s]
+  {:data (when-let [vhs (:variation.strain/_strain s)]
+           (for [vh vhs
+                 :let [variation (:variation/_strain vh)]]
+             (variation-core/process-variation variation)))
+   :description "alleles contained in the strain"})
+
+(defn genes [s]
+  {:data (when-let [genes (:gene/_strain s)]
+           (map pack-obj genes))
+   :description "genes contained in the strain"})
+
+(defn transgenes [s]
+  {:data (when-let [tgs (:transgene/_strain s)] 
+             (map pack-obj tgs))
+   :description "transgenes carried by the strain"})
+
+(def widget
+  {:name generic/name-field
+   :rearrangements rearrangements
+   :clones clones
+;   :alleles alleles
+   :genes genes
+   :transgenes transgenes})

--- a/src/rest_api/classes/strain/widgets/origin.clj
+++ b/src/rest_api/classes/strain/widgets/origin.clj
@@ -1,0 +1,86 @@
+(ns rest-api.classes.strain.widgets.origin
+  (:require
+    [clojure.string :as str]
+    [rest-api.formatters.date :as dates]
+    [rest-api.classes.generic-fields :as generic]
+    [rest-api.formatters.object :as obj :refer [pack-obj]]))
+
+(defn substrate [s]
+  {:data (when-let [s (:strain/substrate s)]
+         (str/capitalize (str/replace s #"_" " ")))
+   :description "the substrate the strain was isolated on"})
+
+(defn place [s]
+  {:data (:strain/place s)
+   :description "the place where the strain was isolated"})
+
+(defn contact [s] ; this is not found in the database
+  {:data (when-let [contacts (:strain/contact s)]
+          (pack-obj (first contacts)))
+   :description "the person who built the strain, or who to contact about it"})
+
+(defn sampled-by [s]
+  {:data (first (:strain/sampled-by s))
+   :description "the person who sampled the strain"})
+
+(defn date-received [s]
+  {:data (when-let [d (first (:strain/cgc-received s))]
+           (dates/format-date4 d))
+   :description "date the strain was received at the CGC"})
+
+(defn gps-coordinates [s]
+  {:data (when-let [c (:strain/geolocation s)]
+           {:longitude (:strain.geolocation/longitude c)
+            :latitude (:strain.geolocation/latitude c)})
+   :description "GPS coordinates of where the strain was isolated"})
+
+(defn associated-organisms [s]
+  {:data (when-let [as (:strain/associated-organisms s)]
+           (map :species/id as))
+   :description "the place where the strain was isolated"})
+
+(defn made-by [s]
+  {:data (when-let [ps (:strain/made-by s)]
+           (pack-obj (first ps)))
+   :description "the person who built the strain"})
+
+(defn isolated-by [s]
+  {:data (when-let [ps (:strain/isolated-by s)]
+             (map pack-obj ps))
+   :description "the person who isolated the strain"})
+
+(defn life-stage [s]
+  {:data (when-let [ls (:strain/life-stage s)]
+           (pack-obj (first ls)))
+   :description "the life stage the strain was in when isolated"})
+
+(defn date-isolated [s]
+  {:data (when-let [d (:strain/date s)]
+          (dates/format-date4 d))
+   :description "the date the strain was isolated"})
+
+(defn landscape [s]
+  {:data (when-let [ls (:strain/landscape s)]
+         (str/capitalize (str/replace  (name ls) #"-" " ")))
+   :description "the general landscape where the strain was isolated"})
+
+(defn log-size-of-population [s]
+  {:data (:strain/log-size-of-population s)
+   :description "the log size of the population when isolated"})
+
+(def widget
+  {:name generic/name-field
+   :laboratory generic/laboratory
+   :substrate substrate
+   :place place
+   :contact contact
+   :sampled_by sampled-by
+   :date_received date-received
+   :gps_coordinates gps-coordinates
+   :associated_organisms associated-organisms
+   :made_by made-by
+   :isolated_by isolated-by
+   :life_stage life-stage
+   :date_isolated date-isolated
+   :landscape landscape
+   :log_size_of_population log-size-of-population})

--- a/src/rest_api/classes/variation/core.clj
+++ b/src/rest_api/classes/variation/core.clj
@@ -1,0 +1,168 @@
+(ns rest-api.classes.variation.core
+  (:require
+   [clojure.string :as str]
+   [pseudoace.utils :as pace-utils]
+   [rest-api.formatters.object :as obj :refer [pack-obj]]))
+
+(def ^{:private true} molecular-change-effects
+  {:molecular-change/missense "Missense"
+   :molecular-change/nonsense "Nonsense"
+   :molecular-change/frameshift "Frameshift"
+   :molecular-change/silent "Silent"
+   :molecular-change/splice-site "Splice site"
+   :molecular-change/promoter "Promoter"
+   :molecular-change/genomic-neighbourhood "Genomic neighbourhood"
+   :molecular-change/regulatory-feature "Regulatory feature"
+   :molecular-change/readthrough "Readthrough"})
+
+(def ^{:private true} molecular-change-kinds
+  {:molecular-change/intron "Intron"
+   :molecular-change/coding-exon "Coding exon"
+   :molecular-change/utr-5 "5' UTR"
+   :molecular-change/utr-3 "3' UTR"})
+
+(defn- process-aa-change [molecular-change]
+  (pace-utils/cond-let
+   [n]
+   (first (:molecular-change/missense molecular-change))
+   (:molecular-change.missense/text n)
+
+   (:molecular-change/nonsense molecular-change)
+   (:molecular-change.nonsense/text n)))
+
+(defn- process-aa-position [molecular-change]
+  (pace-utils/cond-let
+   [n]
+   (first (:molecular-change/missense molecular-change))
+   (:molecular-change.missense/int n)
+
+   (:molecular-change/nonsense molecular-change)
+   (nth (re-find #"\((\d+)\)"
+                 (:molecular-change.nonsense/text n)) 1)))
+
+(defn- process-aa-composite [molecular-change]
+  (let [change (process-aa-change molecular-change)
+        position (process-aa-position molecular-change)]
+    (if (and change position)
+      (let [change-parts (str/split change #"\s+")]
+        (->>
+         [(first change-parts) position (nth change-parts 2)]
+         (map str/capitalize)
+         (str/join ""))))))
+
+(defn- change-set
+  "Return a the set of keys of all maps in `change-map-seqs`."
+  [& change-map-seqs]
+  (->> (apply concat change-map-seqs)
+       (mapcat keys)
+       (set)))
+
+;; TODO: split up and refactor this function.
+(defn process-variation [var & {:keys [window]
+                                 :or {window 20}}]
+  (let [slice (comp seq (partial take 20))
+        cds-changes (slice (:variation/predicted-cds var))
+        trans-changes (slice (:variation/transcript var))
+        gene-changes (slice (:variation/gene var))]
+    (pace-utils/vmap
+     :variation
+     (pack-obj "variation" var)
+
+     :type
+     (if (:variation/transposon-insertion var)
+       "transposon insertion"
+       (str/join ", "
+                 (or
+                  (pace-utils/those
+                   (if (:variation/engineered-allele var)
+                     "Engineered allele")
+                   (if (:variation/allele var)
+                     "Allele")
+                   (if (:variation/snp var)
+                     "SNP")
+                   (if (:variation/confirmed-snp var)
+                     "Confirmed SNP")
+                   (if (:variation/predicted-snp var)
+                     "Predicted SNP")
+                   (if (:variation/reference-strain-digest var)
+                     "RFLP"))
+                  ["unknown"])))
+
+     :method_name
+     (if-let [method (:variation/method var)]
+       (format "<a class=\"longtext\" tip=\"%s\">%s</a>"
+               (or (:method.remark/text
+                    (first (:method/remark methods)))
+                   "")
+               (str/replace (:method/id method) #"_" " ")))
+
+     ;; don't populate since we're coming from gene...
+     :gene nil
+
+     :molecular_change
+     (cond
+       (:variation/substitution var)
+       "Substitution"
+
+       (:variation/insertion var)
+       "Insertion"
+
+       (:variation/deletion var)
+       "Deletion"
+
+       (:variation/inversion var)
+       "Inversion"
+
+       (:variation/tandem-duplication var)
+       "Tandem_duplication"
+
+       :default
+       "Not curated")
+     :locations
+     (let [changes (change-set cds-changes gene-changes trans-changes)]
+       (->> (map molecular-change-kinds changes)
+            (filter identity)))
+     :effects
+     (let [changes (change-set cds-changes gene-changes trans-changes)]
+       (->> changes
+            (map molecular-change-effects)
+            (filter identity)
+            (not-empty)))
+     :aa_change
+     (->> (map process-aa-change cds-changes)
+          (filter identity)
+          (not-empty))
+     :aa_position
+     (->> (map process-aa-position cds-changes)
+          (filter identity)
+          (not-empty))
+     :composite_change
+     (->> (map process-aa-composite cds-changes)
+          (filter identity)
+          (not-empty))
+     :isoform
+     (->> (for [cc cds-changes
+                :when (or (:molecular-change/missense cc)
+                          (:molecular-change/nonsense cc))]
+            (pack-obj "cds" (:variation.predicted-cds/cds cc)))
+          (seq)
+          (not-empty))
+     :phen_count
+     (count (:variation/phenotype var))
+     :strain
+     (->> (:variation/strain var)
+          (map :variation.strain/strain)
+          (map #(pack-obj "strain" %))
+          (not-empty))
+     :sources
+     (let [var-refs (:variation/reference var)
+           sources (if (empty? var-refs)
+                     (map #(let [packed (pack-obj %)]
+                             (into packed
+                                   {:label
+                                    (str/replace (:label packed)
+                                                 #"_" " ")}))
+                          (:variation/analysis var))
+                     (map #(pack-obj (:variation.reference/paper %))
+                          var-refs))]
+           (not-empty sources)))))


### PR DESCRIPTION
This pull request is a little bit more involved. It contains the remaining widgets for strain:

- contains
- origin

I have gone through and have found stains that have all the fields. I have next to no worries that this is producing the right data. 