### PR TITLE
Added and tested sequence feature widgets for cds, operon, pseudogene…

### DIFF
--- a/src/rest_api/classes/cds.clj
+++ b/src/rest_api/classes/cds.clj
@@ -3,6 +3,7 @@
     [rest-api.classes.gene.widgets.external-links :as external-links]
     ;[rest-api.classes.cds.widgets.overview :as overview]
     [rest-api.classes.cds.widgets.location :as location]
+    [rest-api.classes.cds.widgets.feature :as feature]
     [rest-api.classes.cds.widgets.references :as references]
     [rest-api.routing :as routing]))
 
@@ -11,5 +12,6 @@
    :widget
    {;:overview overview/widget not complete -  has some calculations that would need to be verified
     :location location/widget
+    :feature feature/widget
     :external_links external-links/widget
     :references references/widget}})

--- a/src/rest_api/classes/cds/widgets/feature.clj
+++ b/src/rest_api/classes/cds/widgets/feature.clj
@@ -6,18 +6,17 @@
 
 (defn associated-features [cds]
   (let [db (d/entity-db cds)
-        data  (->>
-                (d/q '[:find [?f ...]
-                       :in $ ?cds
-                       :where
-                       [?fg :feature.associated-with-cds/cds ?cds]
-                       [?f :feature/associated-with-cds ?fg]]
-                   db (:db/id cds))
-                (map (partial feature/associated-feature db))
-                (seq))]
-    {:data (not-empty data)
+        data (->> (d/q '[:find [?f ...]
+                         :in $ ?cds
+                         :where
+                         [?fg :feature.associated-with-cds/cds ?cds]
+                         [?f :feature/associated-with-cds ?fg]]
+                       db (:db/id cds))
+                  (map (partial feature/associated-feature db))
+                  (seq))]
+    {:data data
      :description "Features associated with this CDS"}))
 
 (def widget
-    {:name generic/name-field
-     :features associated-features})
+  {:name generic/name-field
+   :features associated-features})

--- a/src/rest_api/classes/cds/widgets/feature.clj
+++ b/src/rest_api/classes/cds/widgets/feature.clj
@@ -1,0 +1,23 @@
+(ns rest-api.classes.cds.widgets.feature
+  (:require
+    [datomic.api :as d]
+    [rest-api.classes.feature.core :as feature]
+    [rest-api.classes.generic-fields :as generic]))
+
+(defn associated-features [cds]
+  (let [db (d/entity-db cds)
+        data  (->>
+                (d/q '[:find [?f ...]
+                       :in $ ?cds
+                       :where
+                       [?fg :feature.associated-with-cds/cds ?cds]
+                       [?f :feature/associated-with-cds ?fg]]
+                   db (:db/id cds))
+                (map (partial feature/associated-feature db))
+                (seq))]
+    {:data (not-empty data)
+     :description "Features associated with this CDS"}))
+
+(def widget
+    {:name generic/name-field
+     :features associated-features})

--- a/src/rest_api/classes/feature/core.clj
+++ b/src/rest_api/classes/feature/core.clj
@@ -1,0 +1,57 @@
+(ns rest-api.classes.feature.core
+  (:require
+   [clojure.string :as str]
+   [rest-api.formatters.object :as obj :refer [pack-obj]]
+   [rest-api.classes.generic-fields :as generic]
+   [datomic.api :as d]))
+
+(defn- expr-pattern [db fid]
+  (->> (d/q '[:find [?e ...]
+              :in $ ?f
+              :where
+              [?ef :expr-pattern.associated-feature/feature ?f]
+              [?e :expr-pattern/associated-feature ?ef]
+              [?e :expr-pattern/anatomy-term _]]
+            db fid)
+       (map
+        (fn [eid]
+          (let [expr (d/entity db eid)]
+            {:text
+             (map #(pack-obj "anatomy-term" (:expr-pattern.anatomy-term/anatomy-term %))
+                  (:expr-pattern/anatomy-term expr))
+             :evidence {:by (pack-obj "expr-pattern" expr)}})))
+       (seq)))
+
+(defn- interaction [feature]
+  (->> (:interaction.feature-interactor/_feature feature)
+       (map #(pack-obj "interaction" (:interaction/_feature-interactor %)))
+       (seq)))
+
+(defn- bounded-by [feature]
+  (->> (:feature/bound-by-product-of feature)
+       (map #(pack-obj (:feature.bound-by-product-of/gene %)))
+       (seq)))
+
+(defn- transcription-factor [feature]
+  (when-first [f (:feature/associated-with-transcription-factor feature)]
+    (pack-obj
+     "transcription-factor"
+     (:feature.associated-with-transcription-factor/transcription-factor
+      f))))
+
+(defn associated-feature [db fid]
+  (let [feature (d/entity db fid)
+        method (-> (:locatable/method feature)
+                   (:method/id))
+        inter (interaction feature)
+        ep (expr-pattern db fid)
+        bbpo (bounded-by feature)
+        tf (transcription-factor feature)]
+    {:name (pack-obj "feature" feature)
+     :description (first (:feature/description feature))
+     :method (if (not (nil? method))
+               (str/replace method #"_" " "))
+     :interaction (not-empty inter)
+     :expr_pattern (not-empty ep)
+     :bounded_by (not-empty bbpo)
+     :tf tf}))

--- a/src/rest_api/classes/gene/widgets/feature.clj
+++ b/src/rest_api/classes/gene/widgets/feature.clj
@@ -1,81 +1,23 @@
 (ns rest-api.classes.gene.widgets.feature
   (:require
-   [clojure.string :as str]
-   [rest-api.formatters.object :refer [pack-obj]]
-   [rest-api.classes.sequence.main :as sequence-fns]
-   [rest-api.classes.generic-fields :as generic]
-   [datomic.api :as d]))
-
-(defn- not-nil [xs]
-  (if (nil? xs)
-    []
-    xs))
-
-(defn- expr-pattern [db fid]
-  (->> (d/q '[:find [?e ...]
-              :in $ ?f
-              :where
-              [?ef :expr-pattern.associated-feature/feature ?f]
-              [?e :expr-pattern/associated-feature ?ef]
-              [?e :expr-pattern/anatomy-term _]]
-            db fid)
-       (map
-        (fn [eid]
-          (let [expr (d/entity db eid)]
-            {:text
-             (map #(pack-obj "anatomy-term" (:expr-pattern.anatomy-term/anatomy-term %))
-                  (:expr-pattern/anatomy-term expr))
-             :evidence {:by (pack-obj "expr-pattern" expr)}})))
-       (seq)))
-
-(defn- interaction [feature]
-  (->> (:interaction.feature-interactor/_feature feature)
-       (map #(pack-obj "interaction" (:interaction/_feature-interactor %)))
-       (seq)))
-
-(defn- bounded-by [feature]
-  (->> (:feature/bound-by-product-of feature)
-       (map #(pack-obj "gene" (:feature.bound-by-product-of/gene %)))
-       (seq)))
-
-(defn- transcription-factor [feature]
-  (when-first [f (:feature/associated-with-transcription-factor feature)]
-    (pack-obj
-     "transcription-factor"
-     (:feature.associated-with-transcription-factor/transcription-factor
-      f))))
-
-(defn- associated-feature [db fid]
-  (let [feature (d/entity db fid)
-        method (-> (:locatable/method feature)
-                   (:method/id))
-        inter (interaction feature)
-        ep (expr-pattern db fid)
-        bbpo (bounded-by feature)
-        tf (transcription-factor feature)]
-    {:name (pack-obj "feature" feature)
-     :description (first (:feature/description feature))
-     :method (if (not (nil? method))
-               (str/replace method #"_" " "))
-     :interaction (not-nil inter)
-     :expr_pattern (not-nil ep)
-     :bounded_by (not-nil bbpo)
-     :tf tf}))
+    [rest-api.classes.feature.core :as feature]
+    [rest-api.classes.sequence.main :as sequence-fns]
+    [rest-api.classes.generic-fields :as generic]
+    [datomic.api :as d]))
 
 (defn associated-features [gene]
   (let [db (d/entity-db gene)
-        data  (->>
-                (d/q '[:find [?f ...]
-                       :in $ ?gene
-                       :where
-                       [?fg :feature.associated-with-gene/gene ?gene]
-                       [?f :feature/associated-with-gene ?fg]]
-                   db (:db/id gene))
-                (map (partial associated-feature db))
-                (seq))]
-    {:data (not-nil data)
-     :description
-     "Features associated with this Gene"}))
+        data (->>
+               (d/q '[:find [?f ...]
+                      :in $ ?gene
+                      :where
+                      [?fg :feature.associated-with-gene/gene ?gene]
+                      [?f :feature/associated-with-gene ?fg]]
+                    db (:db/id gene))
+               (map (partial feature/associated-feature db))
+               (seq))]
+    {:data (not-empty data)
+     :description "Features associated with this Gene"}))
 
 (defn- segment-to-position [gene segment gbrowse]
   (let [[start, stop] (->> segment

--- a/src/rest_api/classes/operon.clj
+++ b/src/rest_api/classes/operon.clj
@@ -1,6 +1,7 @@
 (ns rest-api.classes.operon
   (:require
     [rest-api.classes.operon.widgets.overview :as overview]
+    [rest-api.classes.operon.widgets.feature :as feature]
     [rest-api.classes.operon.widgets.location :as location]
     [rest-api.classes.operon.widgets.references :as references]
     [rest-api.routing :as routing]))
@@ -10,4 +11,5 @@
    :widget
    {:overview overview/widget
     :location location/widget
+    :feature feature/widget
     :references references/widget}})

--- a/src/rest_api/classes/operon/widgets/feature.clj
+++ b/src/rest_api/classes/operon/widgets/feature.clj
@@ -6,18 +6,17 @@
 
 (defn associated-features [operon]
   (let [db (d/entity-db operon)
-        data  (->>
-                (d/q '[:find [?f ...]
-                       :in $ ?operon
-                       :where
-                       [?fg :feature.associated-with-operon/operon ?operon]
-                       [?f :feature/associated-with-operon ?fg]]
-                   db (:db/id operon))
-                (map (partial feature/associated-feature db))
-                (seq))]
-    {:data (not-empty data)
+        data (->> (d/q '[:find [?f ...]
+                         :in $ ?operon
+                         :where
+                         [?fg :feature.associated-with-operon/operon ?operon]
+                         [?f :feature/associated-with-operon ?fg]]
+                       db (:db/id operon))
+                  (map (partial feature/associated-feature db))
+                  (seq))]
+    {:data data
      :description "Features associated with this operon"}))
 
 (def widget
-    {:name generic/name-field
-     :features associated-features})
+  {:name generic/name-field
+   :features associated-features})

--- a/src/rest_api/classes/operon/widgets/feature.clj
+++ b/src/rest_api/classes/operon/widgets/feature.clj
@@ -1,0 +1,23 @@
+(ns rest-api.classes.operon.widgets.feature
+  (:require
+    [datomic.api :as d]
+    [rest-api.classes.feature.core :as feature]
+    [rest-api.classes.generic-fields :as generic]))
+
+(defn associated-features [operon]
+  (let [db (d/entity-db operon)
+        data  (->>
+                (d/q '[:find [?f ...]
+                       :in $ ?operon
+                       :where
+                       [?fg :feature.associated-with-operon/operon ?operon]
+                       [?f :feature/associated-with-operon ?fg]]
+                   db (:db/id operon))
+                (map (partial feature/associated-feature db))
+                (seq))]
+    {:data (not-empty data)
+     :description "Features associated with this operon"}))
+
+(def widget
+    {:name generic/name-field
+     :features associated-features})

--- a/src/rest_api/classes/pseudogene.clj
+++ b/src/rest_api/classes/pseudogene.clj
@@ -1,6 +1,7 @@
 (ns rest-api.classes.pseudogene
   (:require
     [rest-api.classes.pseudogene.widgets.overview :as overview]
+    [rest-api.classes.pseudogene.widgets.feature :as feature]
     [rest-api.classes.pseudogene.widgets.location :as location]
     [rest-api.routing :as routing]))
 
@@ -8,4 +9,5 @@
   {:entity-ns "pseudogene"
    :widget
    {:overview overview/widget
+    :feature feature/widget
     :location location/widget}})

--- a/src/rest_api/classes/pseudogene/widgets/feature.clj
+++ b/src/rest_api/classes/pseudogene/widgets/feature.clj
@@ -1,0 +1,23 @@
+(ns rest-api.classes.pseudogene.widgets.feature
+  (:require
+    [datomic.api :as d]
+    [rest-api.classes.feature.core :as feature]
+    [rest-api.classes.generic-fields :as generic]))
+
+(defn associated-features [pseudogene]
+  (let [db (d/entity-db pseudogene)
+        data  (->>
+                (d/q '[:find [?f ...]
+                       :in $ ?pseudogene
+                       :where
+                       [?fg :feature.associated-with-pseudogene/pseudogene ?pseudogene]
+                       [?f :feature/associated-with-pseudogene ?fg]]
+                   db (:db/id pseudogene))
+                (map (partial feature/associated-feature db))
+                (seq))]
+    {:data (not-empty data)
+     :description "Features associated with this pseudogene"}))
+
+(def widget
+    {:name generic/name-field
+     :features associated-features})

--- a/src/rest_api/classes/pseudogene/widgets/feature.clj
+++ b/src/rest_api/classes/pseudogene/widgets/feature.clj
@@ -6,18 +6,17 @@
 
 (defn associated-features [pseudogene]
   (let [db (d/entity-db pseudogene)
-        data  (->>
-                (d/q '[:find [?f ...]
-                       :in $ ?pseudogene
-                       :where
-                       [?fg :feature.associated-with-pseudogene/pseudogene ?pseudogene]
-                       [?f :feature/associated-with-pseudogene ?fg]]
-                   db (:db/id pseudogene))
-                (map (partial feature/associated-feature db))
-                (seq))]
-    {:data (not-empty data)
+        data (->> (d/q '[:find [?f ...]
+                         :in $ ?pseudogene
+                         :where
+                         [?fg :feature.associated-with-pseudogene/pseudogene ?pseudogene]
+                         [?f :feature/associated-with-pseudogene ?fg]]
+                       db (:db/id pseudogene))
+                  (map (partial feature/associated-feature db))
+                  (seq))]
+    {:data data
      :description "Features associated with this pseudogene"}))
 
 (def widget
-    {:name generic/name-field
-     :features associated-features})
+  {:name generic/name-field
+   :features associated-features})

--- a/src/rest_api/classes/transcript.clj
+++ b/src/rest_api/classes/transcript.clj
@@ -3,6 +3,7 @@
    [rest-api.classes.gene.widgets.external-links :as external-links]
    ;[rest-api.classes.transcript.widgets.overview :as overview]
    [rest-api.classes.transcript.widgets.location :as location]
+   [rest-api.classes.transcript.widgets.feature :as feature]
    [rest-api.classes.transcript.widgets.references :as references]
    [rest-api.classes.gene.expression :as exp]
    [rest-api.formatters.object :as obj]
@@ -37,6 +38,7 @@
     :expression expression-widget
     :external_links external-links/widget
     :location location/widget
+    :feature feature/widget
     :references references/widget}
    :field
    {:fpkm_expression_summary_ls exp/fpkm-expression-summary-ls}})

--- a/src/rest_api/classes/transcript/widgets/feature.clj
+++ b/src/rest_api/classes/transcript/widgets/feature.clj
@@ -6,18 +6,17 @@
 
 (defn associated-features [transcript]
   (let [db (d/entity-db transcript)
-        data  (->>
-                (d/q '[:find [?f ...]
-                       :in $ ?transcript
-                       :where
-                       [?fg :feature.associated-with-transcript/transcript ?transcript]
-                       [?f :feature/associated-with-transcript ?fg]]
-                   db (:db/id transcript))
-                (map (partial feature/associated-feature db))
-                (seq))]
-    {:data (not-empty data)
+        data (->> (d/q '[:find [?f ...]
+                         :in $ ?transcript
+                         :where
+                         [?fg :feature.associated-with-transcript/transcript ?transcript]
+                         [?f :feature/associated-with-transcript ?fg]]
+                       db (:db/id transcript))
+                  (map (partial feature/associated-feature db))
+                  (seq))]
+    {:data data
      :description "Features associated with this transcript"}))
 
 (def widget
-    {:name generic/name-field
-     :features associated-features})
+  {:name generic/name-field
+   :features associated-features})

--- a/src/rest_api/classes/transcript/widgets/feature.clj
+++ b/src/rest_api/classes/transcript/widgets/feature.clj
@@ -1,0 +1,23 @@
+(ns rest-api.classes.transcript.widgets.feature
+  (:require
+    [datomic.api :as d]
+    [rest-api.classes.feature.core :as feature]
+    [rest-api.classes.generic-fields :as generic]))
+
+(defn associated-features [transcript]
+  (let [db (d/entity-db transcript)
+        data  (->>
+                (d/q '[:find [?f ...]
+                       :in $ ?transcript
+                       :where
+                       [?fg :feature.associated-with-transcript/transcript ?transcript]
+                       [?f :feature/associated-with-transcript ?fg]]
+                   db (:db/id transcript))
+                (map (partial feature/associated-feature db))
+                (seq))]
+    {:data (not-empty data)
+     :description "Features associated with this transcript"}))
+
+(def widget
+    {:name generic/name-field
+     :features associated-features})

--- a/src/rest_api/classes/transposon.clj
+++ b/src/rest_api/classes/transposon.clj
@@ -2,10 +2,12 @@
   (:require
     [rest-api.classes.transposon.widgets.overview :as overview]
     [rest-api.classes.transposon.widgets.location :as location]
+    [rest-api.classes.transposon.widgets.feature :as feature]
     [rest-api.routing :as routing]))
 
 (routing/defroutes
   {:entity-ns "transposon"
    :widget
    {:overview overview/widget
+    :feature feautre/widget
     :location location/widget}})

--- a/src/rest_api/classes/transposon.clj
+++ b/src/rest_api/classes/transposon.clj
@@ -9,5 +9,5 @@
   {:entity-ns "transposon"
    :widget
    {:overview overview/widget
-    :feature feautre/widget
+    :feature feature/widget
     :location location/widget}})

--- a/src/rest_api/classes/transposon/widgets/feature.clj
+++ b/src/rest_api/classes/transposon/widgets/feature.clj
@@ -1,0 +1,23 @@
+(ns rest-api.classes.transposon.widgets.feature
+  (:require
+    [datomic.api :as d]
+    [rest-api.classes.feature.core :as feature]
+    [rest-api.classes.generic-fields :as generic]))
+
+(defn associated-features [transposon]
+  (let [db (d/entity-db transposon)
+        data  (->>
+                (d/q '[:find [?f ...]
+                       :in $ ?transposon
+                       :where
+                       [?fg :feature.associated-with-transposon/transposon ?transposon]
+                       [?f :feature/associated-with-transposon ?fg]]
+                   db (:db/id transposon))
+                (map (partial feature/associated-feature db))
+                (seq))]
+    {:data (not-empty data)
+     :description "Features associated with this transposon"}))
+
+(def widget
+    {:name generic/name-field
+     :features associated-features})

--- a/src/rest_api/classes/transposon/widgets/feature.clj
+++ b/src/rest_api/classes/transposon/widgets/feature.clj
@@ -6,18 +6,17 @@
 
 (defn associated-features [transposon]
   (let [db (d/entity-db transposon)
-        data  (->>
-                (d/q '[:find [?f ...]
-                       :in $ ?transposon
-                       :where
-                       [?fg :feature.associated-with-transposon/transposon ?transposon]
-                       [?f :feature/associated-with-transposon ?fg]]
-                   db (:db/id transposon))
-                (map (partial feature/associated-feature db))
-                (seq))]
-    {:data (not-empty data)
+        data (->> (d/q '[:find [?f ...]
+                         :in $ ?transposon
+                         :where
+                         [?fg :feature.associated-with-transposon/transposon ?transposon]
+                         [?f :feature/associated-with-transposon ?fg]]
+                       db (:db/id transposon))
+                  (map (partial feature/associated-feature db))
+                  (seq))]
+    {:data data
      :description "Features associated with this transposon"}))
 
 (def widget
-    {:name generic/name-field
-     :features associated-features})
+  {:name generic/name-field
+   :features associated-features})

--- a/src/rest_api/db/sql/sequence.sql
+++ b/src/rest_api/db/sql/sequence.sql
@@ -8,7 +8,7 @@ JOIN typelist as t ON t.id=f.typeid
 WHERE n.name = :name
 
 -- :name sequence-features-where-type :? :*
--- :doc Retrieve all sequences for a feautre by id whre of type transcript, CDS, mRNA or scpecified type
+-- :doc Retrieve all sequences for a feature by id whre of type transcript, CDS, mRNA or scpecified type
 SELECT f.id,f.typeid,t.tag as type,f.seqid,l.seqname,f.start,f.end,f.strand
 FROM feature as f
 JOIN name as n ON n.id=f.id


### PR DESCRIPTION
Added and tested sequence feature widgets for:
- cds
- operon
- pseudogene
- transcript
- transposon

There is only one Operon with associated features (CEOP3666). I feel like we could either include a widget or not for the Operon page. I am leaning toward adding it. Either way we could have a REST endpoint for this widget. 

Also to node is this time I took on more the style that you ( @sibyl229 ) suggested - it is a good fit. Where we don't dynamically generate the keyword. 

I have switched port 3000 to be running this branch. I have gone through each of the widgets and it appears as if they are all running correctly!