### PR TITLE
Adding history wigets for protein, paper and feature pages

### DIFF
--- a/src/rest_api/classes/feature.clj
+++ b/src/rest_api/classes/feature.clj
@@ -1,6 +1,7 @@
 (ns rest-api.classes.feature
   (:require
     [rest-api.classes.feature.widgets.overview :as overview]
+    [rest-api.classes.feature.widgets.history :as history]
     [rest-api.classes.feature.widgets.location :as location]
     [rest-api.routing :as routing]))
 
@@ -8,4 +9,5 @@
   {:entity-ns "feature"
    :widget
    {:overview overview/widget
+    :history history/widget
     :location location/widget}})

--- a/src/rest_api/classes/feature/widgets/history.clj
+++ b/src/rest_api/classes/feature/widgets/history.clj
@@ -1,0 +1,39 @@
+(ns rest-api.classes.feature.widgets.history
+  (:require
+    [rest-api.classes.generic-fields :as generic]
+    [rest-api.formatters.object :as obj :refer  [pack-obj]]))
+
+(defn history [f]
+  {:data (not-empty
+           (remove
+             nil?
+             (flatten
+               (conj
+                 []
+                 (when-let [holder (:feature/merged-into f)]
+                   {:action "Merged into"
+                    :remark (let [pobj (pack-obj (:feature.merged-into/feature holder))]
+                               (if-let [e (obj/get-evidence holder)]
+                                 {:text pobj
+                                  :evidence e}
+                                 pobj))})
+                 (when-let [holders (:feature.merged-into/_feature f)]
+                   (for [holder holders]
+                     {:action "Acquires merge"
+                      :remark (let [pobj (pack-obj (:feature/_merged-into holder))]
+                                 (if-let [e (obj/get-evidence holder)]
+                                   {:text pobj
+                                    :evidence e}
+                                   pobj))}))
+                 (when-let [holders (:feature/deprecated f)]
+                   (for [holder holders]
+                     {:action "Deprecated"
+                      :remarks (if-let [e (obj/get-evidence holder)]
+                                 {:text (:feature.deprecated/text holder)
+                                  :evidence holder}
+                                 (:feature.deprecated/text holder))}))))))
+   :description "the curatorial history of the gene"})
+
+(def widget
+    {:name generic/name-field
+     :history_lite history})

--- a/src/rest_api/classes/feature/widgets/history.clj
+++ b/src/rest_api/classes/feature/widgets/history.clj
@@ -13,18 +13,18 @@
                  (when-let [holder (:feature/merged-into f)]
                    {:action "Merged into"
                     :remark (let [pobj (pack-obj (:feature.merged-into/feature holder))]
-                               (if-let [e (obj/get-evidence holder)]
-                                 {:text pobj
-                                  :evidence e}
-                                 pobj))})
+                              (if-let [e (obj/get-evidence holder)]
+                                {:text pobj
+                                 :evidence e}
+                                pobj))})
                  (when-let [holders (:feature.merged-into/_feature f)]
                    (for [holder holders]
                      {:action "Acquires merge"
                       :remark (let [pobj (pack-obj (:feature/_merged-into holder))]
-                                 (if-let [e (obj/get-evidence holder)]
-                                   {:text pobj
-                                    :evidence e}
-                                   pobj))}))
+                                (if-let [e (obj/get-evidence holder)]
+                                  {:text pobj
+                                   :evidence e}
+                                  pobj))}))
                  (when-let [holders (:feature/deprecated f)]
                    (for [holder holders]
                      {:action "Deprecated"
@@ -35,5 +35,5 @@
    :description "the curatorial history of the gene"})
 
 (def widget
-    {:name generic/name-field
-     :history_lite history})
+  {:name generic/name-field
+   :history_lite history})

--- a/src/rest_api/classes/paper.clj
+++ b/src/rest_api/classes/paper.clj
@@ -2,10 +2,12 @@
   (:require
     [rest-api.classes.gene.widgets.external-links :as external-links]
     [rest-api.classes.paper.widgets.overview :as overview]
+    [rest-api.classes.paper.widgets.history :as history]
     [rest-api.routing :as routing]))
 
 (routing/defroutes
   {:entity-ns "paper"
    :widget
    {:overview overview/widget
+    :history history/widget
     :external_links external-links/widget}})

--- a/src/rest_api/classes/paper/widgets/history.clj
+++ b/src/rest_api/classes/paper/widgets/history.clj
@@ -1,0 +1,23 @@
+(ns rest-api.classes.paper.widgets.history
+  (:require
+    [clojure.string :as str]
+    [rest-api.classes.generic-fields :as generic]
+    [rest-api.classes.paper.core :as paper-generic]
+    [rest-api.formatters.object :as obj :refer [pack-obj]]))
+
+(defn history [p]
+  {:data (remove
+           nil?
+           (conj
+             []
+             (when-let [pmi (:paper/merged-into p)]
+               {:action "Merged into"
+                :remarks (pack-obj pmi)})
+             (when-let [pam (:paper/_merge-into p)]
+               {:action "Acquires merge"
+                :remarks (pack-obj pam)})))
+   :description "the curatorial history of the gene"})
+
+(def widget
+  {:name generic/name-field
+   :history_lite history})

--- a/src/rest_api/classes/protein.clj
+++ b/src/rest_api/classes/protein.clj
@@ -3,6 +3,7 @@
     [rest-api.classes.gene.widgets.external-links :as external-links]
     ;[rest-api.classes.protein.widgets.overview :as overview]
     [rest-api.classes.protein.widgets.location :as location]
+    [rest-api.classes.protein.widgets.history :as history]
     [rest-api.routing :as routing]))
 
 (routing/defroutes
@@ -10,4 +11,5 @@
    :widget
    {;:overview overview/widget
     :location location/widget
+    :history history/widget
     :external_links external-links/widget}})

--- a/src/rest_api/classes/protein/widgets/history.clj
+++ b/src/rest_api/classes/protein/widgets/history.clj
@@ -1,0 +1,17 @@
+(ns rest-api.classes.protein.widgets.history
+  (:require
+    [rest-api.classes.generic-fields :as generic]))
+
+(defn history [p]
+  {:data (when-let [hs (:protein/history p)]
+           (for [h hs]
+             {:version (:protein.history/int h)
+              :prediction (when-let [prediction (:protein.history/text-c h)]
+                            {:id prediction
+                             :class "gene"})
+              :event (:protein.history/text-b h)}))
+   :description "curatorial history of the protein"})
+
+(def widget
+  {:name generic/name-field
+     :history history})

--- a/src/rest_api/classes/protein/widgets/history.clj
+++ b/src/rest_api/classes/protein/widgets/history.clj
@@ -14,4 +14,4 @@
 
 (def widget
   {:name generic/name-field
-     :history history})
+   :history history})

--- a/src/rest_api/formatters/object.clj
+++ b/src/rest_api/formatters/object.clj
@@ -98,13 +98,15 @@
      (str (author-lastname (first authors)) " et al."))))
 
 (defmethod obj-label "paper" [_ paper]
-  (if-let [year (when (seq (:paper/publication-date paper))
-                  (first
-                    (str/split
-                      (:paper/publication-date paper)
-                      #"-")))]
-    (str (author-list paper) ", " year)
-    (author-list paper)))
+  (if (contains? paper :paper/author)
+    (if-let [year (when (seq (:paper/publication-date paper))
+                    (first
+                      (str/split
+                        (:paper/publication-date paper)
+                        #"-")))]
+      (str (author-list paper) ", " year)
+      (author-list paper))
+    (:paper/id paper)))
 
 (defmethod obj-label "feature" [_ feature]
   (or (:feature/public-name feature)


### PR DESCRIPTION
Created history widgets on the following pages:

- Protein
- Paper
- Features

This has been tested for all of the widgets. Unfortunately they are not too similar. This will require curator testing for sure in order to make sure an edge case has not been missed