### PR TITLE
Finishing expression_cluster widgets

### DIFF
--- a/src/rest_api/classes/anatomy_term.clj
+++ b/src/rest_api/classes/anatomy_term.clj
@@ -2,6 +2,7 @@
   (:require
     [rest-api.classes.gene.widgets.external-links :as external-links]
     ;[rest-api.classes.anatomy-term.widgets.overview :as overview]
+    [rest-api.classes.anatomy-term.widgets.associations :as associations]
     [rest-api.classes.anatomy-term.widgets.ontology-browser :as ontology-browser]
     [rest-api.routing :as routing]))
 
@@ -10,4 +11,5 @@
    :widget
    {;:overview overview/widget
     :ontology_browser ontology-browser/widget
+    :associations associations/widget
     :external_links external-links/widget}})

--- a/src/rest_api/classes/anatomy_term/widgets/associations.clj
+++ b/src/rest_api/classes/anatomy_term/widgets/associations.clj
@@ -1,0 +1,105 @@
+(ns rest-api.classes.anatomy-term.widgets.associations
+  (:require
+    [clojure.string :as str]
+    [pseudoace.utils :as pace-utils]
+    [rest-api.formatters.object :as obj :refer [pack-obj]]
+    [rest-api.classes.generic-fields :as generic]))
+
+(defn transgenes [a]
+  {:data nil
+   :description "transgenes annotated with this anatomy_term"})
+
+(defn gene-ontology [a]
+  {:data (when-let [ghs (:anatomy-term/go-term a)]
+           (for [gh ghs]
+             (pace-utils/vmap
+               :term
+               (when-let [go-term (:anatomy-term.go-term/go-term gh)]
+                 (pack-obj go-term))
+
+               :ao_code
+               (when-let [ao-code (:anatomy-term.go-term/ao-code gh)]
+                 (pack-obj ao-code)))))
+   :description "go_terms associated with this anatomy_term"})
+
+(defn- anatomy-function [a bool]
+  (let [afhs  (if (= bool true)
+                (:anatomy-function.involved/_anatomy-term a)
+                (:anatomy-function.not-involved/_anatomy-term a))]
+    (for [afh afhs
+          :let [af (if (= bool true)
+                     (:anatomy-function/_involved afh)
+                     (:anatomy-function/_not-involved afh))]]
+      {:gene (when-let [gh (:anatomy-function/gene af)]
+               (pack-obj (:anatomy-function.gene/gene gh)))
+       :reference (when-let [reference (:anatomy-function/reference af)]
+                    (pack-obj reference))
+       :af_data (:anatomy-function/id af)
+       :bp_inv (when-let [hs (:anatomy-function/involved af)]
+                 (for [h hs]
+                   {:text (:anatomy-term.term/text
+                            (:anatomy-term/term
+                              (:anatomy-function.involved/anatomy-term h)))
+                    :evidence (obj/get-evidence h)}))
+       :bp_not_inv (when-let [hs (:anatomy-function/not-involved af)]
+                     (for [h hs]
+                       {:text (:anatomy-term.term/text
+                                (:anatomy-term/term
+                                  (:anatomy-function.not-involved/anatomy-term h)))
+                        :evidence (obj/get-evidence h)}))
+
+       :phenotype (when-let [ph (:anatomy-function/phenotype af)]
+                    (let [phenotype (:anatomy-function.phenotype/phenotype ph)]
+                      (if-let [evidence (obj/get-evidence ph)]
+                        {:text (pack-obj phenotype)
+                         :evidence evidence}
+                        (pack-obj phenotype))))
+       :assay (when-let [hs (:anatomy-function/assay af)]
+                (for [h hs]
+                  {:text (:ao-code/id (:anatomy-function.assay/ao-code h))
+                   :evidence (when-let [genotypes (:condition/genotype
+                                                    (:anatomy-function.assay/condition h))]
+                               {:genotype (str/join "<br /> " genotypes)})}))})))
+
+(defn anatomy-functions [a]
+  {:data (anatomy-function a true)
+   :description "anatomy_functions associatated with this anatomy_term"})
+
+(defn anatomy-function-nots [a]
+  {:data (anatomy-function a false)
+   :description "anatomy_functions associatated with this anatomy_term"})
+
+(defn expression-clusters [a]
+  {:data (when-let [hs (:expression-cluster.anatomy-term/_anatomy-term a)]
+           (for [h hs
+                 :let [ec (:expression-cluster/_anatomy-term h)]]
+             {:description (first (:expression-cluster/description ec))
+              :expression_cluster (pack-obj ec)}))
+   :description "expression cluster data"})
+
+(defn expression-patterns [a]
+  {:data (when-let [hs (:expr-pattern.anatomy-term/_anatomy-term a)]
+           (for [h hs
+                 :let [ep (:expr-pattern/_anatomy-term h)]]
+             {:description (when-let [patterns (:expr-pattern/pattern ep)]
+                              (str/join "<br /> " patterns))
+              :expression_pattern (pack-obj ep)
+              :certainty nil
+              :reference (when-let [hs (:expr-pattern/reference ep)]
+                           (let [paper (:expr-pattern.reference/paper (first hs))]
+                             (:paper/id paper)))
+              :gene (when-let [g (:expr-pattern/gene ep)]
+                      (pack-obj (:expr-pattern.gene/gene (first g))))
+              :author (when-let [a (:expr-pattern/author ep)]
+                        (map pack-obj a))}))
+   :description (str "expression patterns associated with the Anatomy_term: " (:anatomy-term/id a))})
+
+(def widget
+  {:name generic/name-field
+   :transgenes transgenes
+      :gene_ontology gene-ontology
+   :anatomy_function_nots anatomy-function-nots
+   :expression_clusters expression-clusters
+   :expression_patterns expression-patterns
+   :anatomy_functions anatomy-functions
+   })

--- a/src/rest_api/classes/expression_cluster.clj
+++ b/src/rest_api/classes/expression_cluster.clj
@@ -1,6 +1,10 @@
 (ns rest-api.classes.expression-cluster
   (:require
     [rest-api.classes.expression-cluster.widgets.overview :as overview]
+    [rest-api.classes.expression-cluster.widgets.associations :as associations]
+    [rest-api.classes.expression-cluster.widgets.clustered-data :as clustered-data]
+    [rest-api.classes.expression-cluster.widgets.genes :as genes]
+    [rest-api.classes.expression-cluster.widgets.regulation :as regulation]
     [rest-api.classes.expression-cluster.widgets.references :as references]
     [rest-api.routing :as routing]))
 
@@ -8,4 +12,8 @@
   {:entity-ns "expression-cluster"
    :widget
    {:overview overview/widget
+    :associations associations/widget
+    :clustered_data clustered-data/widget
+    :genes genes/widget
+    :regulation regulation/widget
     :references references/widget}})

--- a/src/rest_api/classes/expression_cluster/widgets/associations.clj
+++ b/src/rest_api/classes/expression_cluster/widgets/associations.clj
@@ -1,0 +1,42 @@
+(ns rest-api.classes.expression-cluster.widgets.associations
+  (:require
+    [rest-api.formatters.object :as obj :refer [pack-obj]]
+    [rest-api.classes.generic-fields :as generic]))
+
+(defn life-stages [ec]
+  {:data (when-let [lss (:expression-cluster/life-stage ec)]
+           (for [ls lss]
+             {:life_stages (pack-obj ls)
+              :definition (first (:life-stage/definition ls))}))
+   :description "Life stages associated with this expression cluster"})
+
+(defn go-terms [ec] ; non in the database
+  {:data (when-let [go-terms (:expression-cluster/go-term ec)]
+           (map pack-obj go-terms))
+   :description "GO terms associated with this expression cluster"})
+
+(defn anatomy-terms [ec]
+  {:data (when-let [aths (:expression-cluster/anatomy-term ec)]
+           (for [ath aths
+                 :let [at (:expression-cluster.anatomy-term/anatomy-term ath)]]
+             {:anatomy_term (pack-obj at)
+              :definition (:anatomy-term.definition/text
+                            (:anatomy-term/definition at))}))
+
+   :description "anatomy terms associated with this expression cluster"})
+
+(defn processes [ec]
+  {:data (when-let [phs (:wbprocess.expression-cluster/_expression-cluster ec)]
+           (for [ph phs
+                 :let [wbprocess (:wbprocess/_expression-cluster ph)]]
+             {:processes (pack-obj wbprocess)
+              :definition (:wbprocess.summary/text
+                            (:wbprocess/summary wbprocess))}))
+   :description "Processes associated with this expression cluster"})
+
+(def widget
+  {:name generic/name-field
+   :life_stages life-stages
+   :go_terms go-terms
+   :anatomy_terms anatomy-terms
+   :processes processes})

--- a/src/rest_api/classes/expression_cluster/widgets/clustered_data.clj
+++ b/src/rest_api/classes/expression_cluster/widgets/clustered_data.clj
@@ -1,0 +1,30 @@
+(ns rest-api.classes.expression-cluster.widgets.clustered-data
+  (:require
+    [rest-api.formatters.object :as obj :refer  [pack-obj]]
+    [rest-api.classes.generic-fields :as generic]))
+
+(defn microarray [ec]
+  {:data (when-let [mrhs (:expression-cluster/microarray-results ec)]
+           (for [mrh mrhs
+                 :let [mr (:expression-cluster.microarray-results/microarray-results mrh)]]
+             {:minimum (:microarray-results.min/value
+                         (:microarray-results/min mr))
+              :experiment (when-let [result (:microarray-results.results/microarray-experiment
+                                              (first (:microarray-results/results mr)))]
+                              (pack-obj result))
+              :maximum (:microarray-results.max/value
+                         (:microarray-results/max mr))
+              :microarray (pack-obj mr)}))
+   :description "microarray results from expression cluster"})
+
+(defn sage-tags [ec] ; non in the database
+  {:data (when-let [sths (:expression-cluster/sage-tag ec)]
+           (for [sth sths
+                 :let [sage-tag (:expression-cluster.sage-tag/sage-tag sth)]]
+              (pack-obj sage-tag)))
+   :description "Sage tags associated with this expression_cluster"})
+
+(def widget
+  {:name generic/name-field
+   :microarray microarray
+   :sage_tags sage-tags})

--- a/src/rest_api/classes/expression_cluster/widgets/clustered_data.clj
+++ b/src/rest_api/classes/expression_cluster/widgets/clustered_data.clj
@@ -11,7 +11,7 @@
                          (:microarray-results/min mr))
               :experiment (when-let [result (:microarray-results.results/microarray-experiment
                                               (first (:microarray-results/results mr)))]
-                              (pack-obj result))
+                              (:microarray-experiment/id result))
               :maximum (:microarray-results.max/value
                          (:microarray-results/max mr))
               :microarray (pack-obj mr)}))

--- a/src/rest_api/classes/expression_cluster/widgets/genes.clj
+++ b/src/rest_api/classes/expression_cluster/widgets/genes.clj
@@ -4,10 +4,11 @@
     [rest-api.classes.generic-fields :as generic]))
 
 (defn genes [ec]
-  {:data (when-let [ghs (:expression-cluster/gene ec)]
-           (for [gh ghs
-                 :let [gene (:expression-cluster.gene/gene gh)]]
-             (pack-obj gene)))
+  {:data (some->> (:expression-cluster/gene ec)
+                  (map :expression-cluster.gene/gene)
+                  (distinct)
+                  (map pack-obj)
+                  (sort-by :label))
    :description (str "The name and WormBase internal ID of " (:expression-cluster/id ec))})
 
 (def widget

--- a/src/rest_api/classes/expression_cluster/widgets/genes.clj
+++ b/src/rest_api/classes/expression_cluster/widgets/genes.clj
@@ -1,0 +1,15 @@
+(ns rest-api.classes.expression-cluster.widgets.genes
+  (:require
+    [rest-api.formatters.object :as obj :refer [pack-obj]]
+    [rest-api.classes.generic-fields :as generic]))
+
+(defn genes [ec]
+  {:data (when-let [ghs (:expression-cluster/gene ec)]
+           (for [gh ghs
+                 :let [gene (:expression-cluster.gene/gene gh)]]
+             (pack-obj gene)))
+   :description (str "The name and WormBase internal ID of " (:expression-cluster/id ec))})
+
+(def widget
+  {:name generic/name-field
+   :genes genes})

--- a/src/rest_api/classes/expression_cluster/widgets/regulation.clj
+++ b/src/rest_api/classes/expression_cluster/widgets/regulation.clj
@@ -3,22 +3,22 @@
     [rest-api.formatters.object :as obj :refer [pack-obj]]
     [rest-api.classes.generic-fields :as generic]))
 
-(defn regulation-by-molecule [ec]
+(defn regulated-by-molecule [ec]
   {:data (when-let [molecules (:expression-cluster/regulated-by-molecule ec)]
            (map pack-obj molecules))
    :description "Molecule regulating this expression cluster"})
 
-(defn regulation-by-gene [ec]
+(defn regulated-by-gene [ec]
   {:data (when-let [genes (:expression-cluster/regulated-by-gene ec)]
            (map pack-obj genes))
    :description "Gene regulating this expression cluster"})
 
-(defn regulation-by-treatment [ec]
+(defn regulated-by-treatment [ec]
   {:data (first (:expression-cluster/regulated-by-treatment ec))
    :description "Treatment regulating this expression cluster"})
 
 (def widget
   {:name generic/name-field
-   :regulation_by_molecule regulation-by-molecule
-   :regulation_by_gene regulation-by-gene
-   :regulation_by_treatment regulation-by-treatment})
+   :regulated_by_molecule regulated-by-molecule
+   :regulated_by_gene regulated-by-gene
+   :regulated_by_treatment regulated-by-treatment})

--- a/src/rest_api/classes/expression_cluster/widgets/regulation.clj
+++ b/src/rest_api/classes/expression_cluster/widgets/regulation.clj
@@ -1,0 +1,24 @@
+(ns rest-api.classes.expression-cluster.widgets.regulation
+  (:require
+    [rest-api.formatters.object :as obj :refer [pack-obj]]
+    [rest-api.classes.generic-fields :as generic]))
+
+(defn regulation-by-molecule [ec]
+  {:data (when-let [molecules (:expression-cluster/regulated-by-molecule ec)]
+           (map pack-obj molecules))
+   :description "Molecule regulating this expression cluster"})
+
+(defn regulation-by-gene [ec]
+  {:data (when-let [genes (:expression-cluster/regulated-by-gene ec)]
+           (map pack-obj genes))
+   :description "Gene regulating this expression cluster"})
+
+(defn regulation-by-treatment [ec]
+  {:data (first (:expression-cluster/regulated-by-treatment ec))
+   :description "Treatment regulating this expression cluster"})
+
+(def widget
+  {:name generic/name-field
+   :regulation_by_molecule regulation-by-molecule
+   :regulation_by_gene regulation-by-gene
+   :regulation_by_treatment regulation-by-treatment})

--- a/src/rest_api/classes/sequence/main.clj
+++ b/src/rest_api/classes/sequence/main.clj
@@ -6,9 +6,11 @@
     [pseudoace.utils :as pace-utils]
     [rest-api.db.sequence :as wb-seq]))
 
-(defn sequence-features [db-name gene-id]
- (let [db ((keyword db-name) wb-seq/sequence-dbs)]
-   (wb-seq/get-features db gene-id)))
+(defn sequence-features [db-name id role]
+  (let [db ((keyword db-name) wb-seq/sequence-dbs)]
+    (if (= role "variation")
+      (wb-seq/get-features-by-attribute db id)
+      (wb-seq/get-features db id))))
 
 (defn get-segments [object]
   (let [id-kw (first (filter #(= (name %) "id") (keys object)))
@@ -17,7 +19,7 @@
 	   g-species (generic-functions/xform-species-name species-name)
 	   sequence-database (seqdb/get-default-sequence-database g-species)]
      (when sequence-database
-	(sequence-features sequence-database (id-kw object))))))
+	(sequence-features sequence-database (id-kw object) role)))))
 
 (defn longest-segment [segments]
   (first

--- a/src/rest_api/classes/transposon.clj
+++ b/src/rest_api/classes/transposon.clj
@@ -3,6 +3,7 @@
     [rest-api.classes.transposon.widgets.overview :as overview]
     [rest-api.classes.transposon.widgets.location :as location]
     [rest-api.classes.transposon.widgets.feature :as feature]
+    [rest-api.classes.transposon.widgets.associations :as associations]
     [rest-api.routing :as routing]))
 
 (routing/defroutes
@@ -10,4 +11,5 @@
    :widget
    {:overview overview/widget
     :feature feature/widget
+    :associations associations/widget
     :location location/widget}})

--- a/src/rest_api/classes/transposon/widgets/associations.clj
+++ b/src/rest_api/classes/transposon/widgets/associations.clj
@@ -1,0 +1,23 @@
+(ns rest-api.classes.transposon.widgets.associations
+  (:require
+    [rest-api.formatters.object :as obj :refer  [pack-obj]]
+    [rest-api.classes.generic-fields :as generic]))
+
+(defn sequence-field [t]
+  {:data (when-let [chs (:transposon/corresponding-cds t)] t
+           (for [ch chs
+                 :let [cds (:transposon.corresponding-cds/cds ch)]]
+             (pack-obj cds)))
+   :description "Sequences associated with this transposon"})
+
+(defn gene [t]
+  {:data (when-let [gths (:gene.corresponding-transposon/_transposon t)]
+           (for [gth gths
+                 :let [gene (:gene/_corresponding-transposon gth)]]
+             (pack-obj gene)))
+   :description "Gene(s) associated with this transposon"})
+
+(def widget
+  {:name generic/name-field
+   :gene gene
+   :sequence sequence-field})

--- a/src/rest_api/classes/transposon/widgets/associations.clj
+++ b/src/rest_api/classes/transposon/widgets/associations.clj
@@ -4,17 +4,21 @@
     [rest-api.classes.generic-fields :as generic]))
 
 (defn sequence-field [t]
-  {:data (when-let [chs (:transposon/corresponding-cds t)] t
-           (for [ch chs
-                 :let [cds (:transposon.corresponding-cds/cds ch)]]
-             (pack-obj cds)))
+  {:data (when-let [chs (:transposon/corresponding-cds t)]
+           (sort-by
+             :label
+             (for [ch chs
+                   :let [cds (:transposon.corresponding-cds/cds ch)]]
+               (pack-obj cds))))
    :description "Sequences associated with this transposon"})
 
 (defn gene [t]
   {:data (when-let [gths (:gene.corresponding-transposon/_transposon t)]
-           (for [gth gths
-                 :let [gene (:gene/_corresponding-transposon gth)]]
-             (pack-obj gene)))
+           (sort-by
+             :label
+             (for [gth gths
+                   :let [gene (:gene/_corresponding-transposon gth)]]
+               (pack-obj gene))))
    :description "Gene(s) associated with this transposon"})
 
 (def widget

--- a/src/rest_api/db/sequence.clj
+++ b/src/rest_api/db/sequence.clj
@@ -54,6 +54,12 @@
 (defn get-features [db-spec feature-name]
   (sequencesql/get-features db-spec {:name feature-name}))
 
+(defn get-features-by-attribute [db-spec feature-name]
+  (let [attributes (sequencesql/get-attribute-id-by-name db-spec {:name feature-name})]
+    (flatten
+      (for [attribute attributes]
+        (sequencesql/get-features-by-id db-spec  attribute)))))
+
 (defn sequence-features-where-type [db-spec feature-name method]
   (sequencesql/sequence-features-where-type
     db-spec

--- a/src/rest_api/db/sql/sequence.sql
+++ b/src/rest_api/db/sql/sequence.sql
@@ -7,6 +7,20 @@ JOIN locationlist as l ON l.id=f.seqid
 JOIN typelist as t ON t.id=f.typeid
 WHERE n.name = :name
 
+-- :name get-attribute-id-by-name :? :*
+-- :doc Retrieve all sequences for a feature by id
+SELECT id
+FROM attribute
+WHERE attribute_value= :name
+
+-- :name get-features-by-id :? :*
+-- :doc Retrieve all sequences for a feature by id
+SELECT f.id,f.typeid,t.tag as type,f.seqid,l.seqname,f.start,f.end,f.strand
+FROM feature as f
+JOIN locationlist as l ON l.id=f.seqid
+JOIN typelist as t ON t.id=f.typeid
+WHERE f.id = :id
+
 -- :name sequence-features-where-type :? :*
 -- :doc Retrieve all sequences for a feature by id whre of type transcript, CDS, mRNA or scpecified type
 SELECT f.id,f.typeid,t.tag as type,f.seqid,l.seqname,f.start,f.end,f.strand


### PR DESCRIPTION
This branch is currently running on staging to show the results

This pull request adds:

- associations
- clustered_data
- genes
- and regulation

*These were relatively simple. I don't anticipate any issues but would appreciate if anyone finds any. 

@khowe and @tharris I am including the two of you because I noticed that the Eperiment field in the Microarray table in the Clustered data widget was never populated. Or at least I couldn't find an example. I think that I have it correct on staging. Please compare:

http://www.wormbase.org/species/c_elegans/expression_cluster/WBPaper00005475:Aging-regulated#12--10

and
http://staging.wormbase.org/species/c_elegans/expression_cluster/WBPaper00005475:Aging-regulated#12--10

Let me know if you think it is correct. I took the first microarray experiment off of the microarray entity. 