### PR TITLE
Attempt to reduce memory usage on datomic dev sever

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -56,6 +56,7 @@
           :dependencies [[org.clojure/tools.trace "0.7.9"]
                          [ring/ring-devel "1.5.1"]]
           :source-paths ["dev"]
+          :jvm-opts ["-Xmx1G"]
           :env
           {:wb-db-uri "datomic:ddb://us-east-1/WS261/wormbase"
            :swagger-validator-url "http://localhost:8002"}


### PR DESCRIPTION
Hi @mgrbyte @a8wright @azurebrd ,

The Datomic Dev instance is running out of memory, that new testing servers can't be started. I think before we ask for a larger instance, there are a few things we can try. Please let me know whether you think these approaches will help.

- **Reduce the heap size used by testing servers that we spin up.**
The PR address this by setting jvm heap size -Xmx1G for the `dev` profile. Without such a constraint, the longer a testing site is left running (like in screen), the more memory it consumes (in particular the datomic in memory cache).

- **Use `lein trampoline`** command for long running processes, like the testing servers. (lein documentation mentions this https://github.com/technomancy/leiningen/blob/master/doc/TUTORIAL.md#running-code). I'm not certain how much impact this makes. Maybe we should consider `lein trampoline ring server-headless` if the impact is significant.

Please let me know if we can do this or if there are some drawbacks to this. Thank you!