### PR TITLE
added in sequence feature for ticket #5067

### DIFF
--- a/src/rest_api/classes/expr_pattern.clj
+++ b/src/rest_api/classes/expr_pattern.clj
@@ -1,7 +1,7 @@
 (ns rest-api.classes.expr-pattern
   (:require
     ;[rest-api.classes.expr-pattern.widgets.overview :as overview]
-    ;[rest-api.classes.expr-pattern.widgets.details :as details]
+    [rest-api.classes.expr-pattern.widgets.details :as details]
     [rest-api.classes.expr-pattern.widgets.references :as references]
     [rest-api.routing :as routing]))
 
@@ -9,5 +9,5 @@
   {:entity-ns "expr-pattern"
    :widget
    {;:overview overview/widget
-    ;:details details/widget
+    :details details/widget
     :references references/widget}})

--- a/src/rest_api/classes/expr_pattern/widgets/details.clj
+++ b/src/rest_api/classes/expr_pattern/widgets/details.clj
@@ -65,7 +65,7 @@
                          {:anatomy_term (pack-obj term)
                           :definition (:anatomy-term.definition/text
                                         (:anatomy-term/definition term))})))
-   :description "anatomy ontology terms associated with this expression pattern"})
+   :description "Anatomy ontology terms associated with this expression pattern"})
 
 (defn gene-ontology [e]
   {:data (some->> (:expr-pattern/go-term e)
@@ -92,7 +92,21 @@
                     (map :expr-pattern.life-stage/life-stage)
                     (map pack-obj)
                     (sort-by :id))))
-   :description "where the expression has been noted"})
+   :description "Where the expression has been noted"})
+
+(defn sequence-feature [e]
+  {:data (some->> (:expr-pattern/associated-feature e)
+                  (map :expr-pattern.associated-feature/feature)
+                  (map (fn [f]
+                         (let [packed-obj (pack-obj f)]
+                           (if-let [term (:so-term/name
+                                           (first
+                                             (:feature/so-term f)))]
+                             (conj
+                               packed-obj
+                               {:label (str (:label packed-obj) " - " term)})
+                             packed-obj)))))
+   :description (str "The sequence feature associated with the expression profile " (:expr-pattern/id e))})
 
 (def widget
   {:name generic/name-field
@@ -100,4 +114,5 @@
    :anatomy_ontology anatomy-ontology
    :gene_ontology gene-ontology
    :expressed_by expressed-by
+   :sequence_feature sequence-feature
    :expressed_in expressed-in})


### PR DESCRIPTION
This code I wrote a long time ago. I just uncommented it and added the functionality for ticket WormBase/#5067. 

I have added it to the spreadsheet of endpoints to be checked by curators. https://docs.google.com/spreadsheets/d/1ypDxVDHIORayLLD6MdBi2Qb9qpEScoBVadlAv0CVjg0/edit#gid=241814148

I will make sure its checked before release. I honestly don't remember why it was commented. I am sure we will figure that out before it is released. I think it would be because there are a few missing in Datomic compared to ace. But, as we discussed, Matt is working on it and it is not something that should stop us from rolling this out. 

The new field is called "sequence_feature". Right now I am grabbing the first. It wouldn't be too hard to change it to an array, if it should be. 

