### PR TITLE
added experiment widget for microarray results page

### DIFF
--- a/src/rest_api/classes/microarray_results.clj
+++ b/src/rest_api/classes/microarray_results.clj
@@ -1,9 +1,11 @@
 (ns rest-api.classes.microarray-results
   (:require
     [rest-api.classes.microarray-results.widgets.overview :as overview]
+    [rest-api.classes.microarray-results.widgets.experiments :as experiments]
     [rest-api.routing :as routing]))
 
 (routing/defroutes
   {:entity-ns "microarray-results"
    :widget
-   {:overview overview/widget}})
+   {:overview overview/widget
+    :experiments experiments/widget}})

--- a/src/rest_api/classes/microarray_results/widgets/experiments.clj
+++ b/src/rest_api/classes/microarray_results/widgets/experiments.clj
@@ -17,9 +17,10 @@
                   (map :microarray-results.results/microarray-experiment)
                   (map (fn [e]
                          {:experiment (:microarray-experiment/id e)
-                          :temp (first
-                                  (:condition/temperature
-                                    (:microarray-experiment/microarray-sample e)))
+                          :temp (some-> e
+                                        :mocroarray-experiment/microarray-sample
+                                        :condition/temperature
+                                        first)
                           :references (some->> (:microarray-experiment/reference e)
                                                (map pack-obj))
                           :life_stage (when-let [ls (:condition/life-stage

--- a/src/rest_api/classes/microarray_results/widgets/experiments.clj
+++ b/src/rest_api/classes/microarray_results/widgets/experiments.clj
@@ -1,0 +1,53 @@
+(ns rest-api.classes.microarray-results.widgets.experiments
+  (:require
+   [rest-api.classes.generic-fields :as generic]
+   [rest-api.formatters.object :as obj :refer [pack-obj]]))
+
+(defn- range-field [m]
+  {:data {:Max (let [h (:microarray-results/max m)]
+                 {:val (:microarray-results.max/value h)
+                  :experiment (:microarray-experiment/id (:microarray-results.max/experiment h))})
+          :Min (let [h (:microarray-results/min m)]
+                 {:val (:microarray-results.min/value h)
+                  :experiment (:microarray-experiment/id (:microarray-results.min/experiment h))})}
+   :description "The range of the microarray results"})
+
+(defn results [m]
+  {:data (some->> (:microarray-results/results m)
+                  (map :microarray-results.results/microarray-experiment)
+                  (map (fn [e]
+                         {:experiment (:microarray-experiment/id e)
+                          :temp (first
+                                  (:condition/temperature
+                                    (:microarray-experiment/microarray-sample e)))
+                          :references (some->> (:microarray-experiment/reference e)
+                                               (map pack-obj))
+                          :life_stage (when-let [ls (:condition/life-stage
+                                                      (:microarray-experiment/microarray-sample e))]
+                                        (pack-obj (first ls)))
+                          :clusters (some->> (:expression-cluster/_microarray-experiment e)
+                                             (map pack-obj))})))
+   :description "The corresponding cds"})
+
+(defn microarray [m]
+  {:data (some->> (:microarray-results/microarray m)
+                  (map (fn [chip]
+                         {:info (let [info (first (:microarray/chip-info chip))]
+                                  (if-let [remark (map :microarray.remark/text
+                                                       (:microarray/remark chip))]
+                                    (flatten
+                                      [info
+                                       "<b>Remarks:</b>"
+                                       remark])
+                                    info))
+                          :papers (some->> (:microarray/reference chip)
+                                           (map pack-obj))
+                          :experiments (count (:microarray-experiment/_microarray chip))
+                          :type (:microarray/chip-type chip)})))
+   :description "Details about the microarray"})
+
+(def widget
+  {:name generic/name-field
+   :range range-field
+   :results results
+   :miroarray microarray})


### PR DESCRIPTION
This has mainly been tested with: curl -H content-type:application/json http://localhost:3000/rest/widget/microarray_results/171720_x_at/experiments | jq '.'

Will need curator review. 