### PR TITLE
making it pull the sequence for Fosmid and can be used for others

### DIFF
--- a/src/rest_api/classes/clone/widgets/sequences.clj
+++ b/src/rest_api/classes/clone/widgets/sequences.clj
@@ -2,6 +2,7 @@
   (:require
     [clojure.string :as str]
     [rest-api.classes.generic-fields :as generic]
+    [rest-api.classes.sequence.core :as sequence-fns]
     [rest-api.formatters.object :as obj :refer [pack-obj]]))
 
 (defn strand [c]
@@ -60,16 +61,21 @@
 (defn print-sequence [c]
   {:data (some->> (:sequence/_clone c)
 		  (map (fn [s]
-			 (when-let [h (:sequence/dna s)]
+			 (if-let [h (:sequence/dna s)]
 			   {:header "Sequence"
 			    :sequence (-> h
 					  :sequence.dna/dna
 					  :dna/sequence)
 			    :length (:sequence.dna/length h)}
+                           (when-let [refseqobj (sequence-fns/genomic-obj c)]
+                             (when-let [refseq (sequence-fns/get-sequence refseqobj)]
+                           {:header "Reference Sequence"
+                            :sequence refseq
+                            :length (count refseq)}))
 			   )))
 		  (remove nil?)
 		  (not-empty))
-   :description "the sequence of the sequence"})
+   :description "the sequence of the clone"})
 
 (def widget
   {:name generic/name-field

--- a/src/rest_api/classes/sequence/core.clj
+++ b/src/rest_api/classes/sequence/core.clj
@@ -66,7 +66,7 @@
       :id id
       :label label
       :pos_string id
-      :seqment (:seqname segment)
+      :seqname (:seqname segment)
       :start start
       :stop stop
       :taxonomy (get-g-species object role)
@@ -85,3 +85,13 @@
                              ((juxt :start :end))
                              (sort-by +))]
       (create-genomic-location-obj start stop object segment nil true false))))
+
+(defn get-sequence [seqfeature-obj]
+  (let [g-species (:taxonomy seqfeature-obj)
+        sequence-database (seqdb/get-default-sequence-database g-species)]
+    (when sequence-database
+      (let [db ((keyword sequence-database) wb-seq/sequence-dbs)
+            start (:start seqfeature-obj)
+            stop  (:stop seqfeature-obj)
+            location (:seqname seqfeature-obj)]
+        (wb-seq/get-sequence db location start stop)))))

--- a/src/rest_api/db/sql/sequence.sql
+++ b/src/rest_api/db/sql/sequence.sql
@@ -53,3 +53,11 @@ JOIN attributelist as al ON al.id=a.attribute_id
 WHERE a.attribute_value = "WBVar00101112"
 AND al.tag = "variation"
 AND f.object NOT LIKE "%PCoF%";
+
+-- :name get-sequence :? :*
+-- :doc Retrieve raw sequence from location
+SELECT CONVERT(s.sequence using UTF8) as sequence
+FROM sequence as s
+JOIN locationlist as l ON l.id=s.id
+WHERE l.seqname = :location
+AND s.offset = :offset


### PR DESCRIPTION
This has been tested with this endpoint: curl -H content-type:application/json http://localhost:3000/rest/widget/clone/WRM0636cG07/sequences | jq '.'

Once we get it pulled in we can use the functions for other sequences as well. We can also get CG to test it once we have the template changed. 

@sibyl229 the object for the sequence being returned has the header field as "Sequence" for when the actual clone sequence is known and "Reference Sequence" for when it is pulled from the refseqdb. Feel free to suggest other JSON patterns if this does not work well with the template.

