### PR TITLE
265 interaction

### DIFF
--- a/src/rest_api/classes/gene.clj
+++ b/src/rest_api/classes/gene.clj
@@ -6,7 +6,7 @@
    [rest-api.classes.gene.widgets.sequences :as sequences]
    [rest-api.classes.gene.widgets.genetics :as genetics]
    [rest-api.classes.gene.widgets.history :as history]
-   [rest-api.classes.gene.widgets.interactions :as interactions]
+   [rest-api.classes.interaction.core :as interactions]
    [rest-api.classes.gene.widgets.mapping-data :as mapping-data]
    [rest-api.classes.gene.widgets.ontology :as gene-ontology]
    [rest-api.classes.gene.widgets.references :as references]

--- a/src/rest_api/classes/gene/widgets/interactions.clj
+++ b/src/rest_api/classes/gene/widgets/interactions.clj
@@ -457,11 +457,11 @@
        (into {})
        (not-empty)))
 
-(defn- build-interactions [gene arrange-results]
+(defn- build-interactions [interactions interactions-nearby arrange-results]
   (let [edge-vals (comp vec fixup-citations vals :edges)
-        data (obj-interactions gene {} :nearby? false)
+        data interactions
         edges (edge-vals data)
-        results (obj-interactions gene data :nearby? true)
+        results interactions-nearby
         edges-all (edge-vals results)]
     (-> results
         (assoc :phenotypes (collect-phenotypes edges-all))
@@ -484,13 +484,17 @@
   "Produces a data structure suitable for rendering the table listing."
   [gene]
   {:description "genetic and predicted interactions"
-   :data (build-interactions gene arrange-interactions)})
+   :data (let [data (obj-interactions gene {} :nearby? false)
+               results (obj-interactions gene data :nearby? true)]
+           (build-interactions data results arrange-interactions))})
 
 (defn interaction-details
   "Produces a data-structure suitable for rendering a cytoscape graph."
   [gene]
   {:description "addtional nearby interactions"
-   :data (build-interactions gene arrange-interaction-details)})
+   :data (let [data (obj-interactions gene {} :nearby? false)
+               results (obj-interactions gene data :nearby? true)]
+           (build-interactions data results arrange-interaction-details))})
 
 (def widget
   {:name generic/name-field

--- a/src/rest_api/classes/gene/widgets/interactions.clj
+++ b/src/rest_api/classes/gene/widgets/interactions.clj
@@ -45,16 +45,24 @@
   (some-fn :molecule/id :gene/id :rearrangement/id :feature/id))
 
 (def int-rules
-  '[[(gene-interaction ?gene ?int)
+  '[[(gene->interaction-3 ?gene ?ih ?int)
      [?ih :interaction.interactor-overlapping-gene/gene ?gene]
      [?int :interaction/interactor-overlapping-gene ?ih]]
-    [(gene-neighbour ?gene ?neighbour)
-     (gene-interaction ?gene ?ix)
-     [?ix :interaction/interactor-overlapping-gene ?ih]
+    [(gene-interaction ?gene ?int)
+     (gene->interaction-3 ?gene _ ?int)]
+    [(interaction->gene-3 ?int ?ih ?gene)
+     [?int :interaction/interactor-overlapping-gene ?ih]
+     [?ih :interaction.interactor-overlapping-gene/gene ?gene]]
+    [(gene->neighbour-5 ?gene ?gh ?neighbour ?nh ?ix)
+     (gene->interaction-3 ?gene ?gh ?ix)
+     (interaction->gene-3 ?ix ?nh ?neighbour)
+     [(not= ?gene ?neighbour)]
      (not
       [?ix :interaction/type :interaction.type/predicted])
-     [?ih :interaction.interactor-overlapping-gene/gene ?neighbour]
-     [(not= ?gene ?neighbour)]]])
+     ]
+    [(gene-neighbour ?gene ?neighbour)
+     (gene->neighbour-5 ?gene _ ?neighbour _ _)]]
+  )
 
 (defn interactor-idents [db]
   (sort (d/q '[:find [?ident ...]

--- a/src/rest_api/classes/gene/widgets/interactions.clj
+++ b/src/rest_api/classes/gene/widgets/interactions.clj
@@ -190,7 +190,7 @@
               :where
               (gene->neighbour-5-non-predicted ?gene _ ?neighbour1 _ ?i1)
               (gene->neighbour-5-non-predicted ?gene _ ?neighbour2 _ ?i2)
-              (gene->neighbour-5-non-predicted ?neighbour1 ?nh ?neighbour2 ?n2h ?int)]
+              (gene->neighbour-5 ?neighbour1 ?nh ?neighbour2 ?n2h ?int)]
             db int-rules gene)))
 
 ;; (defn gene-nearby-interactions [db gene]

--- a/src/rest_api/classes/gene/widgets/interactions.clj
+++ b/src/rest_api/classes/gene/widgets/interactions.clj
@@ -385,9 +385,9 @@
 (defn- assoc-showall [data nearby?]
   (assoc data :showall (or (< (count (:edges data)) 100) nearby?)))
 
-(defn- edge-key [x y type-name phenotype]
+(defn- edge-key [x y type-name direction phenotype]
   (str/trimr
-   (str x " " y " " type-name " " (:label phenotype))))
+   (str x " " y " " type-name " " direction " " (:label phenotype))))
 
 
 
@@ -396,14 +396,14 @@
   (let [roles [effector affected]
         packed-roles (annotate-interactor-roles data type-name roles)
         [packed-effector packed-affected] packed-roles
-        [e-name a-name] (map :label packed-roles)
+        [e-name a-name] (map :id packed-roles)
         papers (:interaction/paper interaction)
         packed-papers (pack-papers papers)
         phenotype (first (interaction-phenotype-kw interaction))
         packed-int (pack-obj "interaction" interaction)
         packed-phenotype (pack-obj "phenotype" phenotype)
-        e-key (edge-key e-name a-name type-name packed-phenotype)
-        a-key (edge-key a-name e-name type-name packed-phenotype)
+        e-key (edge-key e-name a-name type-name direction packed-phenotype)
+        a-key (edge-key a-name e-name type-name direction packed-phenotype)
         assoc-int (partial assoc-interaction type-name nearby?)
         result (-> data
                    (assoc-in [:types type-name] 1)
@@ -413,7 +413,8 @@
                       (get-in result [:edges e-key])
                       (update-in-edges result e-key packed-int packed-papers)
 
-                      (get-in result [:edges a-key])
+                      (and (= direction "non-directional")
+                           (get-in result [:edges a-key]))
                       (update-in-edges result a-key packed-int packed-papers)
 
                       :default

--- a/src/rest_api/classes/gene/widgets/interactions.clj
+++ b/src/rest_api/classes/gene/widgets/interactions.clj
@@ -56,10 +56,11 @@
     [(gene->neighbour-5 ?gene ?gh ?neighbour ?nh ?ix)
      (gene->interaction-3 ?gene ?gh ?ix)
      (interaction->gene-3 ?ix ?nh ?neighbour)
-     [(not= ?gene ?neighbour)]
+     [(not= ?gene ?neighbour)]]
+    [(gene->neighbour-5-non-predicted ?gene ?gh ?neighbour ?nh ?ix)
+     (gene->neighbour-5 ?gene ?gh ?neighbour ?nh ?ix)
      (not
-      [?ix :interaction/type :interaction.type/predicted])
-     ]
+      [?ix :interaction/type :interaction.type/predicted])]
     [(gene-neighbour ?gene ?neighbour)
      (gene->neighbour-5 ?gene _ ?neighbour _ _)]]
   )
@@ -187,9 +188,9 @@
   (->> (d/q '[:find ?int ?nh ?n2h
               :in $ % ?gene
               :where
-              (gene->neighbour-5 ?gene _ ?neighbour1 _ _)
-              (gene->neighbour-5 ?gene _ ?neighbour2 _ _)
-              (gene->neighbour-5 ?neighbour1 ?nh ?neighbour2 ?n2h ?int)]
+              (gene->neighbour-5-non-predicted ?gene _ ?neighbour1 _ ?i1)
+              (gene->neighbour-5-non-predicted ?gene _ ?neighbour2 _ ?i2)
+              (gene->neighbour-5-non-predicted ?neighbour1 ?nh ?neighbour2 ?n2h ?int)]
             db int-rules gene)))
 
 ;; (defn gene-nearby-interactions [db gene]

--- a/src/rest_api/classes/interaction.clj
+++ b/src/rest_api/classes/interaction.clj
@@ -3,11 +3,13 @@
     [rest-api.classes.gene.widgets.external-links :as external-links]
     [rest-api.classes.interaction.widgets.overview :as overview]
     [rest-api.classes.interaction.widgets.references :as references]
+    [rest-api.classes.interaction.widgets.interactions :as interactions]
     [rest-api.routing :as routing]))
 
 (routing/defroutes
   {:entity-ns "interaction"
    :widget
    {:overview overview/widget
+    :interactions interactions/widget
     :references references/widget
     :external_links external-links/widget}})

--- a/src/rest_api/classes/interaction/core.clj
+++ b/src/rest_api/classes/interaction/core.clj
@@ -46,38 +46,38 @@
   (some-fn :molecule/id :gene/id :rearrangement/id :feature/id))
 
 (def int-rules
-  '[[(x->interaction ?gene ?h ?int)
+  '[[(->interaction ?gene ?h ?int)
      [?h :interaction.interactor-overlapping-gene/gene ?gene]
      [?int :interaction/interactor-overlapping-gene ?h]]
-    [(x->interaction ?feature ?h ?int)
+    [(->interaction ?feature ?h ?int)
      [?h :interaction.feature-interactor/feature ?feature]
      [?int :interaction/feature-interactor ?h]]
-    [(x->interaction ?molecule ?h ?int)
+    [(->interaction ?molecule ?h ?int)
      [?h :interaction.molecule-interactor/molecule ?molecule]
      [?int :interaction/molecule-interactor ?h]]
-    [(x->interaction ?rearrangement ?h ?int)
+    [(->interaction ?rearrangement ?h ?int)
      [?h :interaction.rearrangement/rearrangement ?rearrangement]
      [?int :interaction/rearrangement ?h]]
 
-    [(interaction->x ?int ?h ?gene)
+    [(interaction-> ?int ?h ?gene)
      [?int :interaction/interactor-overlapping-gene ?h]
      [?h :interaction.interactor-overlapping-gene/gene ?gene]]
-    [(interaction->x ?int ?h ?feature)
+    [(interaction-> ?int ?h ?feature)
      [?int :interaction/feature-interactor ?h]
      [?h :interaction.feature-interactor/feature ?feature]]
-    [(interaction->x ?int ?h ?molecule)
+    [(interaction-> ?int ?h ?molecule)
      [?int :interaction/molecule-interactor ?h]
      [?h :interaction.molecule-interactor/molecule ?molecule]]
-    [(interaction->x ?int ?h ?rearrangement)
+    [(interaction-> ?int ?h ?rearrangement)
      [?int :interaction/rearrangement ?h]
      [?h :interaction.rearrangement/rearrangement ?rearrangement]]
-    [(interaction->x ?int ?h ?other)
+    [(interaction-> ?int ?h ?other)
      [?int :interaction/other-interactor ?h]
      [?h :interaction.other-interactor/text ?other]]
 
     [(x->neighbour ?x ?xh ?neighbour ?nh ?ix)
-     (x->interaction ?x ?xh ?ix)
-     (interaction->x ?ix ?nh ?neighbour)
+     (->interaction ?x ?xh ?ix)
+     (interaction-> ?ix ?nh ?neighbour)
      [(not= ?x ?neighbour)]]
     [(x->neighbour-non-predicted ?gene ?gh ?neighbour ?nh ?ix)
      (x->neighbour ?gene ?gh ?neighbour ?nh ?ix)

--- a/src/rest_api/classes/interaction/core.clj
+++ b/src/rest_api/classes/interaction/core.clj
@@ -217,11 +217,14 @@
        db int-rules gene))
 
 (defn gene-nearby-interactions [db gene]
-  (let [neighbours (d/q '[:find (distinct ?neighbour) .
-                          :in $ % ?gene
-                          :where
-                          (x->neighbour-5-non-predicted ?gene _ ?neighbour _ ?int)]
-                        db int-rules gene)]
+  (if-let [neighbours (->>  (d/q '[:find (distinct ?neighbour) .
+                                   :in $ % ?gene
+                                   :where
+                                   (x->neighbour-5-non-predicted ?gene _ ?neighbour _ ?int)]
+                                 db int-rules gene)
+                            ;; remove string-based other-interactors that would cause problem in downstream query
+                            (filter (complement string?))
+                            (seq))]
 
     (d/q '[:find ?int ?nh ?n2h
            :in $ % [?neighbour1 ...] [?neighbour2 ...]

--- a/src/rest_api/classes/interaction/core.clj
+++ b/src/rest_api/classes/interaction/core.clj
@@ -46,53 +46,53 @@
   (some-fn :molecule/id :gene/id :rearrangement/id :feature/id))
 
 (def int-rules
-  '[[(gene->interaction-3 ?gene ?h ?int)
+  '[[(gene->interaction ?gene ?h ?int)
      [?h :interaction.interactor-overlapping-gene/gene ?gene]
      [?int :interaction/interactor-overlapping-gene ?h]]
-    [(feature->interaction-3 ?feature ?h ?int)
+    [(feature->interaction ?feature ?h ?int)
      [?h :interaction.feature-interactor/feature ?feature]
      [?int :interaction/feature-interactor ?h]]
-    [(molecule->interaction-3 ?molecule ?h ?int)
+    [(molecule->interaction ?molecule ?h ?int)
      [?h :interaction.molecule-interactor/molecule ?molecule]
      [?int :interaction/molecule-interactor ?h]]
-    [(rearrangement->interaction-3 ?rearrangement ?h ?int)
+    [(rearrangement->interaction ?rearrangement ?h ?int)
      [?h :interaction.rearrangement/rearrangement ?rearrangement]
      [?int :interaction/rearrangement ?h]]
-    [(x->interaction-3 ?x ?h ?ix)
-     (or (gene->interaction-3 ?x ?h ?ix)
-         (feature->interaction-3 ?x ?h ?ix)
-         (molecule->interaction-3 ?x ?h ?ix)
-         (rearrangement->interaction-3 ?x ?h ?ix))]
+    [(x->interaction ?x ?h ?ix)
+     (or (gene->interaction ?x ?h ?ix)
+         (feature->interaction ?x ?h ?ix)
+         (molecule->interaction ?x ?h ?ix)
+         (rearrangement->interaction ?x ?h ?ix))]
 
-    [(interaction->gene-3 ?int ?h ?gene)
+    [(interaction->gene ?int ?h ?gene)
      [?int :interaction/interactor-overlapping-gene ?h]
      [?h :interaction.interactor-overlapping-gene/gene ?gene]]
-    [(interaction->feature-3 ?int ?h ?feature)
+    [(interaction->feature ?int ?h ?feature)
      [?int :interaction/feature-interactor ?h]
      [?h :interaction.feature-interactor/feature ?feature]]
-    [(interaction->molecule-3 ?int ?h ?molecule)
+    [(interaction->molecule ?int ?h ?molecule)
      [?int :interaction/molecule-interactor ?h]
      [?h :interaction.molecule-interactor/molecule ?molecule]]
-    [(interaction->rearrangement-3 ?int ?h ?rearrangement)
+    [(interaction->rearrangement ?int ?h ?rearrangement)
      [?int :interaction/rearrangement ?h]
      [?h :interaction.rearrangement/rearrangement ?rearrangement]]
-    [(interaction->other-3 ?int ?h ?other)
+    [(interaction->other ?int ?h ?other)
      [?int :interaction/other-interactor ?h]
      [?h :interaction.other-interactor/text ?other]]
 
-    [(interaction->x-3 ?ix ?h ?neighbour)
-     (or (interaction->gene-3 ?ix ?h ?neighbour)
-         (interaction->feature-3 ?ix ?h ?neighbour)
-         (interaction->molecule-3 ?ix ?h ?neighbour)
-         (interaction->rearrangement-3 ?ix ?h ?neighbour)
-         (interaction->other-3 ?ix ?h ?neighbour))]
+    [(interaction->x ?ix ?h ?neighbour)
+     (or (interaction->gene ?ix ?h ?neighbour)
+         (interaction->feature ?ix ?h ?neighbour)
+         (interaction->molecule ?ix ?h ?neighbour)
+         (interaction->rearrangement ?ix ?h ?neighbour)
+         (interaction->other ?ix ?h ?neighbour))]
 
-    [(x->neighbour-5 ?x ?xh ?neighbour ?nh ?ix)
-     (x->interaction-3 ?x ?xh ?ix)
-     (interaction->x-3 ?ix ?nh ?neighbour)
+    [(x->neighbour ?x ?xh ?neighbour ?nh ?ix)
+     (x->interaction ?x ?xh ?ix)
+     (interaction->x ?ix ?nh ?neighbour)
      [(not= ?x ?neighbour)]]
-    [(x->neighbour-5-non-predicted ?gene ?gh ?neighbour ?nh ?ix)
-     (x->neighbour-5 ?gene ?gh ?neighbour ?nh ?ix)
+    [(x->neighbour-non-predicted ?gene ?gh ?neighbour ?nh ?ix)
+     (x->neighbour ?gene ?gh ?neighbour ?nh ?ix)
      (not
       [?ix :interaction/type :interaction.type/predicted])]]
   )
@@ -213,24 +213,23 @@
   (d/q '[:find ?int ?gh ?nh
          :in $ % ?gene
          :where
-         (x->neighbour-5 ?gene ?gh _ ?nh ?int)]
+         (x->neighbour ?gene ?gh _ ?nh ?int)]
        db int-rules gene))
 
 (defn gene-nearby-interactions [db gene]
   (if-let [neighbours (->>  (d/q '[:find (distinct ?neighbour) .
                                    :in $ % ?gene
                                    :where
-                                   (x->neighbour-5-non-predicted ?gene _ ?neighbour _ ?int)]
+                                   (x->neighbour-non-predicted ?gene _ ?neighbour _ ?int)]
                                  db int-rules gene)
                             ;; remove string-based other-interactors that would cause problem in downstream query
                             (filter (complement string?))
                             (seq))]
-
     (d/q '[:find ?int ?nh ?n2h
            :in $ % [?neighbour1 ...] [?neighbour2 ...]
            :where
            [(not= ?neighbour1 ?neighbour2)]
-           (x->neighbour-5 ?neighbour1 ?nh ?neighbour2 ?n2h ?int)]
+           (x->neighbour ?neighbour1 ?nh ?neighbour2 ?n2h ?int)]
          db int-rules neighbours neighbours)
     ))
 

--- a/src/rest_api/classes/interaction/core.clj
+++ b/src/rest_api/classes/interaction/core.clj
@@ -48,15 +48,21 @@
   '[[(gene->interaction-3 ?gene ?h ?int)
      [?h :interaction.interactor-overlapping-gene/gene ?gene]
      [?int :interaction/interactor-overlapping-gene ?h]]
-    [(feature->interaction-3 ?int ?h ?feature)
+    [(feature->interaction-3 ?feature ?h ?int)
      [?h :interaction.feature-interactor/feature ?feature]
      [?int :interaction/feature-interactor ?h]]
-    [(molecule->interaction-3 ?int ?h ?molecule)
+    [(molecule->interaction-3 ?molecule ?h ?int)
      [?h :interaction.molecule-interactor/molecule ?molecule]
      [?int :interaction/molecule-interactor ?h]]
-    [(rearrangement->interaction-3 ?int ?h ?rearrangement)
+    [(rearrangement->interaction-3 ?rearrangement ?h ?int)
      [?h :interaction.rearrangement/rearrangement ?rearrangement]
      [?int :interaction/rearrangement ?h]]
+    [(x->interaction-3 ?x ?h ?ix)
+     (or (gene->interaction-3 ?x ?h ?ix)
+         (feature->interaction-3 ?x ?h ?ix)
+         (molecule->interaction-3 ?x ?h ?ix)
+         (rearrangement->interaction-3 ?x ?h ?ix))]
+
     [(interaction->gene-3 ?int ?h ?gene)
      [?int :interaction/interactor-overlapping-gene ?h]
      [?h :interaction.interactor-overlapping-gene/gene ?gene]]
@@ -69,17 +75,16 @@
     [(interaction->rearrangement-3 ?int ?h ?rearrangement)
      [?int :interaction/rearrangement ?h]
      [?h :interaction.rearrangement/rearrangement ?rearrangement]]
-    [(x->neighbour-5 ?gene ?gh ?neighbour ?nh ?ix)
-     (or (gene->interaction-3 ?gene ?gh ?ix)
-         (feature->interaction-3 ?gene ?gh ?ix)
-         (molecule->interaction-3 ?gene ?gh ?ix)
-         (rearrangement->interaction-3 ?gene ?gh ?ix))
-     (or (interaction->gene-3 ?ix ?nh ?neighbour)
-         (interaction->feature-3 ?ix ?nh ?neighbour)
-         (interaction->molecule-3 ?ix ?nh ?neighbour)
-         (interaction->rearrangement-3 ?ix ?nh ?neighbour)
-         )
-     [(not= ?gene ?neighbour)]]
+    [(interaction->x-3 ?ix ?h ?neighbour)
+     (or (interaction->gene-3 ?ix ?h ?neighbour)
+         (interaction->feature-3 ?ix ?h ?neighbour)
+         (interaction->molecule-3 ?ix ?h ?neighbour)
+         (interaction->rearrangement-3 ?ix ?h ?neighbour))]
+
+    [(x->neighbour-5 ?x ?xh ?neighbour ?nh ?ix)
+     (x->interaction-3 ?x ?xh ?ix)
+     (interaction->x-3 ?ix ?nh ?neighbour)
+     [(not= ?x ?neighbour)]]
     [(x->neighbour-5-non-predicted ?gene ?gh ?neighbour ?nh ?ix)
      (x->neighbour-5 ?gene ?gh ?neighbour ?nh ?ix)
      (not

--- a/src/rest_api/classes/interaction/core.clj
+++ b/src/rest_api/classes/interaction/core.clj
@@ -28,7 +28,8 @@
   (some-fn :interaction.feature-interactor/feature
            :interaction.interactor-overlapping-gene/gene
            :interaction.molecule-interactor/molecule
-           :interaction.rearrangement/rearrangement))
+           :interaction.rearrangement/rearrangement
+           :interaction.other-interactor/text))
 
 (def ^:private interactors
   [:interaction/feature-interactor
@@ -75,11 +76,16 @@
     [(interaction->rearrangement-3 ?int ?h ?rearrangement)
      [?int :interaction/rearrangement ?h]
      [?h :interaction.rearrangement/rearrangement ?rearrangement]]
+    [(interaction->other-3 ?int ?h ?other)
+     [?int :interaction/other-interactor ?h]
+     [?h :interaction.other-interactor/text ?other]]
+
     [(interaction->x-3 ?ix ?h ?neighbour)
      (or (interaction->gene-3 ?ix ?h ?neighbour)
          (interaction->feature-3 ?ix ?h ?neighbour)
          (interaction->molecule-3 ?ix ?h ?neighbour)
-         (interaction->rearrangement-3 ?ix ?h ?neighbour))]
+         (interaction->rearrangement-3 ?ix ?h ?neighbour)
+         (interaction->other-3 ?ix ?h ?neighbour))]
 
     [(x->neighbour-5 ?x ?xh ?neighbour ?nh ?ix)
      (x->interaction-3 ?x ?xh ?ix)

--- a/src/rest_api/classes/interaction/core.clj
+++ b/src/rest_api/classes/interaction/core.clj
@@ -1,4 +1,4 @@
-(ns rest-api.classes.gene.widgets.interactions
+(ns rest-api.classes.interaction.core
   (:require
    [clojure.string :as str]
    [datomic.api :as d]

--- a/src/rest_api/classes/interaction/core.clj
+++ b/src/rest_api/classes/interaction/core.clj
@@ -446,7 +446,7 @@
        (into {})
        (not-empty)))
 
-(defn- build-interactions [db interactions interactions-nearby arrange-results]
+(defn build-interactions [db interactions interactions-nearby arrange-results]
   (let [edge-vals (comp vec fixup-citations vals :edges)
         data (fill-interactions db interactions {} :nearby? false)
         edges (edge-vals data)
@@ -456,7 +456,7 @@
         (assoc :phenotypes (collect-phenotypes edges-all))
         (arrange-results edges edges-all))))
 
-(defn- arrange-interactions [results edges edges-all]
+(defn arrange-interactions [results edges edges-all]
   (if (:showall results)
     (-> (assoc results :edges edges)
         (assoc :edges_all edges-all)
@@ -464,7 +464,7 @@
         (assoc :showall "1"))
     {:edges edges}))
 
-(defn- arrange-interaction-details [results edges edges-all]
+(defn arrange-interaction-details [results edges edges-all]
   (-> results
       (assoc :edges edges-all)
       (update-in [:showall] #(str (if % 1 0)))))

--- a/src/rest_api/classes/interaction/core.clj
+++ b/src/rest_api/classes/interaction/core.clj
@@ -46,46 +46,34 @@
   (some-fn :molecule/id :gene/id :rearrangement/id :feature/id))
 
 (def int-rules
-  '[[(gene->interaction ?gene ?h ?int)
+  '[[(x->interaction ?gene ?h ?int)
      [?h :interaction.interactor-overlapping-gene/gene ?gene]
      [?int :interaction/interactor-overlapping-gene ?h]]
-    [(feature->interaction ?feature ?h ?int)
+    [(x->interaction ?feature ?h ?int)
      [?h :interaction.feature-interactor/feature ?feature]
      [?int :interaction/feature-interactor ?h]]
-    [(molecule->interaction ?molecule ?h ?int)
+    [(x->interaction ?molecule ?h ?int)
      [?h :interaction.molecule-interactor/molecule ?molecule]
      [?int :interaction/molecule-interactor ?h]]
-    [(rearrangement->interaction ?rearrangement ?h ?int)
+    [(x->interaction ?rearrangement ?h ?int)
      [?h :interaction.rearrangement/rearrangement ?rearrangement]
      [?int :interaction/rearrangement ?h]]
-    [(x->interaction ?x ?h ?ix)
-     (or (gene->interaction ?x ?h ?ix)
-         (feature->interaction ?x ?h ?ix)
-         (molecule->interaction ?x ?h ?ix)
-         (rearrangement->interaction ?x ?h ?ix))]
 
-    [(interaction->gene ?int ?h ?gene)
+    [(interaction->x ?int ?h ?gene)
      [?int :interaction/interactor-overlapping-gene ?h]
      [?h :interaction.interactor-overlapping-gene/gene ?gene]]
-    [(interaction->feature ?int ?h ?feature)
+    [(interaction->x ?int ?h ?feature)
      [?int :interaction/feature-interactor ?h]
      [?h :interaction.feature-interactor/feature ?feature]]
-    [(interaction->molecule ?int ?h ?molecule)
+    [(interaction->x ?int ?h ?molecule)
      [?int :interaction/molecule-interactor ?h]
      [?h :interaction.molecule-interactor/molecule ?molecule]]
-    [(interaction->rearrangement ?int ?h ?rearrangement)
+    [(interaction->x ?int ?h ?rearrangement)
      [?int :interaction/rearrangement ?h]
      [?h :interaction.rearrangement/rearrangement ?rearrangement]]
-    [(interaction->other ?int ?h ?other)
+    [(interaction->x ?int ?h ?other)
      [?int :interaction/other-interactor ?h]
      [?h :interaction.other-interactor/text ?other]]
-
-    [(interaction->x ?ix ?h ?neighbour)
-     (or (interaction->gene ?ix ?h ?neighbour)
-         (interaction->feature ?ix ?h ?neighbour)
-         (interaction->molecule ?ix ?h ?neighbour)
-         (interaction->rearrangement ?ix ?h ?neighbour)
-         (interaction->other ?ix ?h ?neighbour))]
 
     [(x->neighbour ?x ?xh ?neighbour ?nh ?ix)
      (x->interaction ?x ?xh ?ix)

--- a/src/rest_api/classes/interaction/widgets/interactions.clj
+++ b/src/rest_api/classes/interaction/widgets/interactions.clj
@@ -1,0 +1,37 @@
+(ns rest-api.classes.interaction.widgets.interactions
+  (:require
+   [clojure.string :as str]
+   [datomic.api :as d]
+   [pseudoace.utils :as pace-utils]
+   [rest-api.classes.generic-fields :as generic]
+   [rest-api.classes.interaction.core :as interaction]
+   [rest-api.formatters.object :refer [pack-obj]]))
+
+(defn interaction-direct-interactions [db interaction]
+  (d/q '[:find ?intx ?g1h ?g2h
+         :in $ % ?intx
+         :where
+         (interaction->x-3 ?intx ?g1h _)
+         (interaction->x-3 ?intx ?g2h _)
+         [(not= ?g1h ?g2h)]]
+       db interaction/int-rules interaction))
+
+(defn interactions
+  "Produces a data structure suitable for rendering the table listing."
+  [interaction]
+  {:description "genetic and predicted interactions"
+   :data (let [db (d/entity-db interaction)
+               ints (interaction-direct-interactions db (:db/id interaction))]
+           (interaction/build-interactions db ints [] interaction/arrange-interactions))})
+
+(defn interaction-details
+  "Produces a data-structure suitable for rendering a cytoscape graph."
+  [interaction]
+  {:description "addtional nearby interactions"
+   :data (let [db (d/entity-db interaction)
+               ints (interaction-direct-interactions db (:db/id interaction))]
+           (interaction/build-interactions db ints [] interaction/arrange-interaction-details))})
+
+(def widget
+  {:name generic/name-field
+   :interactions interactions})

--- a/src/rest_api/classes/interaction/widgets/interactions.clj
+++ b/src/rest_api/classes/interaction/widgets/interactions.clj
@@ -11,8 +11,8 @@
   (d/q '[:find ?intx ?g1h ?g2h
          :in $ % ?intx
          :where
-         (interaction->x ?intx ?g1h _)
-         (interaction->x ?intx ?g2h _)
+         (interaction-> ?intx ?g1h _)
+         (interaction-> ?intx ?g2h _)
          [(not= ?g1h ?g2h)]]
        db interaction/int-rules interaction))
 

--- a/src/rest_api/classes/interaction/widgets/interactions.clj
+++ b/src/rest_api/classes/interaction/widgets/interactions.clj
@@ -11,8 +11,8 @@
   (d/q '[:find ?intx ?g1h ?g2h
          :in $ % ?intx
          :where
-         (interaction->x-3 ?intx ?g1h _)
-         (interaction->x-3 ?intx ?g2h _)
+         (interaction->x ?intx ?g1h _)
+         (interaction->x ?intx ?g2h _)
          [(not= ?g1h ?g2h)]]
        db interaction/int-rules interaction))
 

--- a/src/rest_api/classes/wbprocess.clj
+++ b/src/rest_api/classes/wbprocess.clj
@@ -7,6 +7,7 @@
     [rest-api.classes.wbprocess.widgets.go-term :as go-term]
     [rest-api.classes.wbprocess.widgets.anatomy :as anatomy]
     [rest-api.classes.wbprocess.widgets.expression-clusters :as expression-clusters]
+    [rest-api.classes.wbprocess.widgets.interactions :as interactions]
     [rest-api.classes.wbprocess.widgets.phenotypes :as phenotypes]
     [rest-api.classes.wbprocess.widgets.references :as references]
     [rest-api.routing :as routing]))
@@ -19,6 +20,7 @@
     :pathways pathways/widget
     :expression_clusters expression-clusters/widget
     :molecule molecule/widget
+    :interactions interactions/widget
     :go_term go-term/widget
     :anatomy anatomy/widget
     :genes genes/widget

--- a/src/rest_api/classes/wbprocess/widgets/interactions.clj
+++ b/src/rest_api/classes/wbprocess/widgets/interactions.clj
@@ -13,8 +13,8 @@
          :where
          [?p :wbprocess/interaction ?ih]
          [?ih :wbprocess.interaction/interaction ?intx]
-         (interaction->x ?intx ?g1h _)
-         (interaction->x ?intx ?g2h _)
+         (interaction-> ?intx ?g1h _)
+         (interaction-> ?intx ?g2h _)
          [(not= ?g1h ?g2h)]]
        db interaction/int-rules wbprocess))
 

--- a/src/rest_api/classes/wbprocess/widgets/interactions.clj
+++ b/src/rest_api/classes/wbprocess/widgets/interactions.clj
@@ -1,0 +1,39 @@
+(ns rest-api.classes.wbprocess.widgets.interactions
+  (:require
+   [clojure.string :as str]
+   [datomic.api :as d]
+   [pseudoace.utils :as pace-utils]
+   [rest-api.classes.generic-fields :as generic]
+   [rest-api.classes.interaction.core :as interaction]
+   [rest-api.formatters.object :refer [pack-obj]]))
+
+(defn wbprocess-direct-interactions [db wbprocess]
+  (d/q '[:find ?intx ?g1h ?g2h
+         :in $ % ?p
+         :where
+         [?p :wbprocess/interaction ?ih]
+         [?ih :wbprocess.interaction/interaction ?intx]
+         (interaction->x-3 ?intx ?g1h _)
+         (interaction->x-3 ?intx ?g2h _)
+         [(not= ?g1h ?g2h)]]
+       db interaction/int-rules wbprocess))
+
+(defn interactions
+  "Produces a data structure suitable for rendering the table listing."
+  [wbprocess]
+  {:description "genetic and predicted interactions"
+   :data (let [db (d/entity-db wbprocess)
+               ints (wbprocess-direct-interactions db (:db/id wbprocess))]
+           (interaction/build-interactions db ints [] interaction/arrange-interactions))})
+
+(defn interaction-details
+  "Produces a data-structure suitable for rendering a cytoscape graph."
+  [wbprocess]
+  {:description "addtional nearby interactions"
+   :data (let [db (d/entity-db wbprocess)
+               ints (wbprocess-direct-interactions db (:db/id wbprocess))]
+           (interaction/build-interactions db ints [] interaction/arrange-interaction-details))})
+
+(def widget
+  {:name generic/name-field
+   :interactions interactions})

--- a/src/rest_api/classes/wbprocess/widgets/interactions.clj
+++ b/src/rest_api/classes/wbprocess/widgets/interactions.clj
@@ -13,8 +13,8 @@
          :where
          [?p :wbprocess/interaction ?ih]
          [?ih :wbprocess.interaction/interaction ?intx]
-         (interaction->x-3 ?intx ?g1h _)
-         (interaction->x-3 ?intx ?g2h _)
+         (interaction->x ?intx ?g1h _)
+         (interaction->x ?intx ?g2h _)
          [(not= ?g1h ?g2h)]]
        db interaction/int-rules wbprocess))
 

--- a/src/rest_api/formatters/object.clj
+++ b/src/rest_api/formatters/object.clj
@@ -236,6 +236,9 @@
   "Attempt to determine the class of a WormBase-ish entity-map."
   [obj]
   (cond
+   (string? obj)
+   "text"
+
    (:pcr-product/id obj)
    "pcr_oligo"
 
@@ -295,6 +298,11 @@
                                          (:movie.db-info/accession))]
               (format "http://www.rnai.org/movies/%s" rnai-db-id)))
         ))))
+
+(defmethod pack-obj-helper "text" [class obj & args]
+  {:id obj
+   :label obj
+   :class class})
 
 
 (defn get-evidence [holder]


### PR DESCRIPTION
The objective is to reuse the gene page's interaction widget on wbprocess page and interaction page.

Technical summary:
- The concept of focus gene isn't applicable on other pages. Functions that rely on the focus gene are re-written to avoid focus gene
- Rewrite queries to get the set of correct tuples (`interaction-interactorholder1-interactorholder2`) at query time to avoid subsequent filtering (that is somewhat difficult to track).
- Add interactions widget for wbprocess page and interaction page
- Support string-based "other interactors"