### PR TITLE
Feature/265 interaction

### DIFF
--- a/src/rest_api/classes/interaction.clj
+++ b/src/rest_api/classes/interaction.clj
@@ -12,4 +12,6 @@
    {:overview overview/widget
     :interactions interactions/widget
     :references references/widget
-    :external_links external-links/widget}})
+    :external_links external-links/widget}
+   :field
+   {:interaction_details interactions/interaction-details}})

--- a/src/rest_api/classes/interaction/core.clj
+++ b/src/rest_api/classes/interaction/core.clj
@@ -445,8 +445,8 @@
 (defn build-interactions [db interactions interactions-nearby arrange-results]
   (let [edge-vals (comp vec fixup-citations vals :edges)
         data (fill-interactions db interactions {} :nearby? false)
+        results (fill-interactions db interactions-nearby data :nearby? true)
         edges (edge-vals data)
-        results (fill-interactions db (concat interactions interactions-nearby) {} :nearby? true)
         edges-all (edge-vals results)]
     (-> results
         (assoc :phenotypes (collect-phenotypes edges-all))

--- a/src/rest_api/classes/interaction/core.clj
+++ b/src/rest_api/classes/interaction/core.clj
@@ -437,9 +437,10 @@
        (into {})
        (not-empty)))
 
-(defn build-interactions [db interactions-fun interactions-nearby-fun & {:keys [graph-only-mode?]}]
+(defn build-interactions [db interactions-fun interactions-nearby-fun-raw & {:keys [graph-only-mode?]}]
   (let [ints (interactions-fun)
         data (fill-interactions db ints {} :nearby? false)
+        interactions-nearby-fun (or interactions-nearby-fun-raw (constantly nil))
 
         [include-details? results]
         (if graph-only-mode?
@@ -448,8 +449,7 @@
           ;; whether to include nearby edges based on the number of direct and nearby edges
           (if (> (count (:edges data)) 100)
             [false data]
-            (let [ints-nearby (when interactions-nearby-fun
-                                (interactions-nearby-fun))]
+            (let [ints-nearby (interactions-nearby-fun)]
               (if (> (count ints-nearby) 500)
                 [false data]
                 [true (fill-interactions db ints-nearby data :nearby? true)]))))

--- a/src/rest_api/classes/interaction/core.clj
+++ b/src/rest_api/classes/interaction/core.clj
@@ -351,9 +351,6 @@
        (map (partial pack-obj "paper"))
        (vec)))
 
-(defn- assoc-showall [data nearby?]
-  (assoc data :showall (or (< (count (:edges data)) 100) nearby?)))
-
 (defn- edge-key [x y type-name direction phenotype]
   (str/trimr
    (str x " " y " " type-name " " direction " " (:label phenotype))))
@@ -397,7 +394,7 @@
                                  :phenotype packed-phenotype
                                  :type type-name
                                  :nearby (if nearby? "1" "0")}))]
-       (assoc-showall result* nearby?))))
+       result*)))
 
 (defn- fill-interaction
   [nearby? data [interaction
@@ -425,9 +422,7 @@
                                                 (d/entity db holder1-id)
                                                 (d/entity db holder2-id)
                                                 nearby?))))]
-    (if (and nearby? (> (count ints) 3000))
-      (assoc data :showall "0")
-      (reduce mk-interaction data (mapcat mk-pair-wise ints)))))
+    (reduce mk-interaction data (mapcat mk-pair-wise ints))))
 
 
 (defn- collect-phenotypes
@@ -442,46 +437,33 @@
        (into {})
        (not-empty)))
 
-(defn arrange-interactions [results edges edges-all]
-  (if (:showall results)
-    (-> (assoc results :edges edges)
-        (assoc :edges_all edges-all)
-        (assoc :class "Gene")
-        (assoc :showall "1"))
-    {:edges edges}))
-
-(defn arrange-interaction-details [results edges edges-all]
-  (-> results
-      (assoc :edges edges-all)
-      (update-in [:showall] #(str (if % 1 0)))))
-
-(defn build-interactions [db interactions-fun interactions-nearby-fun & {:keys [force-details?]}]
+(defn build-interactions [db interactions-fun interactions-nearby-fun & {:keys [graph-only-mode?]}]
   (let [ints (interactions-fun)
         data (fill-interactions db ints {} :nearby? false)
 
         [include-details? results]
-        (if force-details?
+        (if graph-only-mode?
           [true (fill-interactions db (interactions-nearby-fun) data :nearby? true)]
-          ;; when force-details? is not set, use the following approach to determine
+          ;; when graph-only-mode? is not set, use the following approach to determine
           ;; whether to include nearby edges based on the number of direct and nearby edges
           (if (> (count (:edges data)) 100)
             [false data]
-            (let [ints-nearby (if interactions-nearby-fun
-                                (interactions-nearby-fun)
-                                [])]
+            (let [ints-nearby (when interactions-nearby-fun
+                                (interactions-nearby-fun))]
               (if (> (count ints-nearby) 500)
                 [false data]
                 [true (fill-interactions db ints-nearby data :nearby? true)]))))
 
-        edge-vals (comp vec fixup-citations vals :edges)
-        edges (edge-vals data)
-        edges-all (if include-details? (edge-vals results) edges)]
-    (if force-details?
-      (arrange-interaction-details results edges edges-all)
+        edge-vals (comp vec fixup-citations vals :edges)]
+    (if graph-only-mode?
       (-> results
-          (assoc :phenotypes (collect-phenotypes edges-all))
-          (assoc :include_details include-details?)
-          (arrange-interactions edges edges-all)))))
+          (assoc :edges_all (edge-vals results))
+          (assoc :include_details include-details?))
+      (-> results
+          (assoc :edges (edge-vals data))
+          (assoc :edges_all (edge-vals results))
+          ;; (assoc :phenotypes (collect-phenotypes (edge-vals results))) ; not used in display now
+          (assoc :include_details include-details?)))))
 
 (defn interactions
   "Produces a data structure suitable for rendering the table listing."
@@ -491,7 +473,7 @@
            (build-interactions db
                                (partial gene-direct-interactions db (:db/id gene))
                                (partial gene-nearby-interactions db (:db/id gene))
-                               :force-details? false))})
+                               :graph-only-mode? false))})
 
 (defn interaction-details
   "Produces a data-structure suitable for rendering a cytoscape graph."
@@ -501,7 +483,7 @@
            (build-interactions db
                                (partial gene-direct-interactions db (:db/id gene))
                                (partial gene-nearby-interactions db (:db/id gene))
-                               :force-details? true))})
+                               :graph-only-mode? true))})
 
 (def widget
   {:name generic/name-field

--- a/src/rest_api/classes/interaction/widgets/interactions.clj
+++ b/src/rest_api/classes/interaction/widgets/interactions.clj
@@ -20,17 +20,21 @@
   "Produces a data structure suitable for rendering the table listing."
   [interaction]
   {:description "genetic and predicted interactions"
-   :data (let [db (d/entity-db interaction)
-               ints (interaction-direct-interactions db (:db/id interaction))]
-           (interaction/build-interactions db ints [] interaction/arrange-interactions))})
+   :data (let [db (d/entity-db interaction)]
+           (interaction/build-interactions db
+                                           (partial interaction-direct-interactions db (:db/id interaction))
+                                           nil
+                                           :force-details? false))})
 
 (defn interaction-details
   "Produces a data-structure suitable for rendering a cytoscape graph."
   [interaction]
   {:description "addtional nearby interactions"
-   :data (let [db (d/entity-db interaction)
-               ints (interaction-direct-interactions db (:db/id interaction))]
-           (interaction/build-interactions db ints [] interaction/arrange-interaction-details))})
+   :data (let [db (d/entity-db interaction)]
+           (interaction/build-interactions db
+                                           (partial interaction-direct-interactions db (:db/id interaction))
+                                           nil
+                                           :force-details? true))})
 
 (def widget
   {:name generic/name-field

--- a/src/rest_api/classes/interaction/widgets/interactions.clj
+++ b/src/rest_api/classes/interaction/widgets/interactions.clj
@@ -24,7 +24,7 @@
            (interaction/build-interactions db
                                            (partial interaction-direct-interactions db (:db/id interaction))
                                            nil
-                                           :force-details? false))})
+                                           :graph-only-mode? false))})
 
 (defn interaction-details
   "Produces a data-structure suitable for rendering a cytoscape graph."
@@ -34,7 +34,7 @@
            (interaction/build-interactions db
                                            (partial interaction-direct-interactions db (:db/id interaction))
                                            nil
-                                           :force-details? true))})
+                                           :graph-only-mode? true))})
 
 (def widget
   {:name generic/name-field

--- a/src/rest_api/classes/wbprocess.clj
+++ b/src/rest_api/classes/wbprocess.clj
@@ -24,4 +24,6 @@
     :go_term go-term/widget
     :anatomy anatomy/widget
     :genes genes/widget
-    :references references/widget}})
+    :references references/widget}
+   :field
+   {:interaction_details interactions/interaction-details}})

--- a/src/rest_api/classes/wbprocess/widgets/interactions.clj
+++ b/src/rest_api/classes/wbprocess/widgets/interactions.clj
@@ -22,17 +22,21 @@
   "Produces a data structure suitable for rendering the table listing."
   [wbprocess]
   {:description "genetic and predicted interactions"
-   :data (let [db (d/entity-db wbprocess)
-               ints (wbprocess-direct-interactions db (:db/id wbprocess))]
-           (interaction/build-interactions db ints [] interaction/arrange-interactions))})
+   :data (let [db (d/entity-db wbprocess)]
+           (interaction/build-interactions db
+                                           (partial wbprocess-direct-interactions db (:db/id wbprocess))
+                                           nil
+                                           :force-details? false))})
 
 (defn interaction-details
   "Produces a data-structure suitable for rendering a cytoscape graph."
   [wbprocess]
   {:description "addtional nearby interactions"
-   :data (let [db (d/entity-db wbprocess)
-               ints (wbprocess-direct-interactions db (:db/id wbprocess))]
-           (interaction/build-interactions db ints [] interaction/arrange-interaction-details))})
+   :data (let [db (d/entity-db wbprocess)]
+           (interaction/build-interactions db
+                                           (partial wbprocess-direct-interactions db (:db/id wbprocess))
+                                           nil
+                                           :force-details? true))})
 
 (def widget
   {:name generic/name-field

--- a/src/rest_api/classes/wbprocess/widgets/interactions.clj
+++ b/src/rest_api/classes/wbprocess/widgets/interactions.clj
@@ -26,7 +26,7 @@
            (interaction/build-interactions db
                                            (partial wbprocess-direct-interactions db (:db/id wbprocess))
                                            nil
-                                           :force-details? false))})
+                                           :graph-only-mode? false))})
 
 (defn interaction-details
   "Produces a data-structure suitable for rendering a cytoscape graph."
@@ -36,7 +36,7 @@
            (interaction/build-interactions db
                                            (partial wbprocess-direct-interactions db (:db/id wbprocess))
                                            nil
-                                           :force-details? true))})
+                                           :graph-only-mode? true))})
 
 (def widget
   {:name generic/name-field


### PR DESCRIPTION
Hi @mgrbyte minor refactoring and performance tweaking here, based on what data is used in the UI. Basically, `interactions` field is *primarily* used to render the table, and *sometimes* also include data to render the graph (when the size of the graph is small). `interaction_details` field is *only* used to render the graph. 
`showall` flag is removed, and replaced with `include_details` to indicate whether data for rendering the graph is included.
Thanks!