### PR TITLE
Feature/variation sequence

### DIFF
--- a/src/rest_api/classes/generic_functions.clj
+++ b/src/rest_api/classes/generic_functions.clj
@@ -4,6 +4,18 @@
     [rest-api.formatters.object :as obj :refer [pack-obj]]
     [clojure.string :as str]))
 
+(defn dna-reverse-complement [dna]
+  (str/replace (str/reverse dna)
+               #"A|C|G|T|a|c|g|t"
+               {"A" "T"
+                "C" "G"
+                "G" "C"
+                "T" "A"
+                "a" "t"
+                "c" "g"
+                "g" "c"
+                "t" "a"}))
+
 (defn xform-species-name
   "Transforms a `species-name` from the WB database into
   a name used to look up connection configuration to a sequence db."

--- a/src/rest_api/classes/rnai.clj
+++ b/src/rest_api/classes/rnai.clj
@@ -3,7 +3,7 @@
     [rest-api.classes.gene.widgets.external-links :as external-links]
     [rest-api.classes.rnai.widgets.phenotypes :as phenotypes]
     [rest-api.classes.rnai.widgets.overview :as overview]
-    ;[rest-api.classes.rnai.widgets.details :as details]
+    [rest-api.classes.rnai.widgets.details :as details]
     [rest-api.classes.rnai.widgets.movies :as movies]
     [rest-api.classes.rnai.widgets.references :as references]
     [rest-api.routing :as routing]))
@@ -14,6 +14,6 @@
    {:overview overview/widget
     :phenotypes phenotypes/widget
     :references references/widget
-    ;:details details/widget
+    :details details/widget
     :movies movies/widget
     :external_links external-links/widget}})

--- a/src/rest_api/classes/variation.clj
+++ b/src/rest_api/classes/variation.clj
@@ -3,7 +3,7 @@
     [rest-api.classes.variation.widgets.overview :as overview]
     [rest-api.classes.variation.widgets.genetics :as genetics]
     [rest-api.classes.variation.widgets.isolation :as isolation]
-    ;[rest-api.classes.variation.widgets.molecular-details :as molecular-details] commented out because it requires the physical sequence information and it turned out to be a rabbit hole. 
+    [rest-api.classes.variation.widgets.molecular-details :as molecular-details]
     [rest-api.classes.variation.widgets.phenotypes :as phenotypes]
     [rest-api.classes.variation.widgets.location :as location]
     [rest-api.classes.gene.widgets.external-links :as external-links]
@@ -16,7 +16,7 @@
    {:overview overview/widget
     :genetics genetics/widget
     :isolation isolation/widget
-    ;:molecular_details molecular-details/widget
+    :molecular_details molecular-details/widget
     :phenotypes phenotypes/widget
     :external_links external-links/widget
     :location location/widget

--- a/src/rest_api/classes/variation/widgets/molecular_details.clj
+++ b/src/rest_api/classes/variation/widgets/molecular_details.clj
@@ -353,9 +353,13 @@
                                                  (second ohs)))}))})))
    :description "experimental assays for detecting this polymorphism"})
 
-(defn affects-splice-site [variation]
-  {:data {:donor nil
-          :acceptor nil}
+(defn affects-splice-site [variation] ; made from WBVar00750883. This was in Ace code but wasn't working and format slightly changed
+  {:data (some->> (:variation/predicted-cds variation)
+                  (map :molecular-change/splice-site)
+                  (map (fn [mc]
+                         {:value (name
+                                   (:molecular-change.splice-site/value mc))
+                          :text (:molecular-change.splice-site/text mc)})))
    :description "Affects splice site"})
 
 (defn polymorphism-status [variation]; WBVar00116162 is predicted
@@ -405,7 +409,7 @@
                {:mutation (if-let [mut (or (:transposon-family/id
                                             (first
                                             (:variation/transposon-insertion variation)))
-                                          (:variation/d variation))] ; meed to check method
+                                          (:variation/d variation))] ; need to check method
                             mut
                             (:variation.insertion/text insertion))
                 :type "Insertion"
@@ -447,7 +451,7 @@
    :description "A variation that alters the reading frame"})
 
 (defn sequencing-status [variation]
-  {:data (if-let [seqstatus (:variation/seqstatus variation)]
+  {:data (when-let [seqstatus (:variation/seqstatus variation)]
            (name seqstatus))
    :description "sequencing status of the variation"})
 

--- a/src/rest_api/classes/variation/widgets/molecular_details.clj
+++ b/src/rest_api/classes/variation/widgets/molecular_details.clj
@@ -161,7 +161,7 @@
                                                    (first (:variation.transpon-insertion variation))))
                                           1))))
                                (if-let [deletion (:variation/deletion variation)]
-                                 (- 0 seq-length)
+                                 (- 1 seq-length)
                                  (if-let [substitution (:variation/substitution variation)]
                                    (- (count (:variation.substitution/alt substitution))
                                       (count (:variation.substitution/ref substitution)))
@@ -266,6 +266,27 @@
                                     :features
                                     (:features mutant-positive)})
 
+                  wildtype-positive-flattened (when (nil? placeholder)
+                                                {:sequence (:sequence wildtype-positive)
+                                                 :features (sort-by
+                                                             :start
+                                                             (vals (:features wildtype-positive)))})
+                  wildtype-negative-flattened (when (nil? placeholder)
+                                                {:sequence (:sequence wildtype-negative)
+                                                 :features (sort-by
+                                                             :start
+                                                             (vals (:features wildtype-negative)))})
+                  mutant-positive-flattened (when (nil? placeholder)
+                                              {:sequence (:sequence mutant-positive)
+                                               :features (sort-by
+                                                           :start
+                                                           (vals (:features mutant-positive)))})
+                  mutant-negative-flattened (when (nil? placeholder)
+                                              {:sequence (:sequence mutant-negative)
+                                               :features (sort-by
+                                                           :start
+                                                           (vals (:features mutant-negative)))})
+
                  species (some->> (:species/assembly (:variation/species variation))
                                   (map (fn [assembly]
                                          (:strain/id (first (:sequence-collection/strain assembly))))))]
@@ -273,13 +294,12 @@
                  (pace-utils/vmap
                    :wildtype (not-empty
                                (pace-utils/vmap
-                                 :positive-strand wildtype-positive
-                                 :negative-strand wildtype-negative))
+                                 :positive-strand wildtype-positive-flattened
+                                 :negative-strand wildtype-negative-flattened))
                    :mutant (not-empty
                              (pace-utils/vmap
-                               :positive-strand mutant-positive
-                               :negative-strand mutant-negative
-                               ))
+                               :positive-strand mutant-positive-flattened
+                               :negative-strand mutant-negative-flattened))
                    :public-name (:variation/public-name variation)
                    :placeholder placeholder)))
    :description "wild type and variant sequences in genomic context"})

--- a/src/rest_api/classes/variation/widgets/molecular_details.clj
+++ b/src/rest_api/classes/variation/widgets/molecular_details.clj
@@ -184,12 +184,15 @@
                                                                         wildtype-sequence)))
                                     :features
                                     {:variation
-                                     {:start (+ padding 1)
+                                     {:type "variation"
+                                      :start (+ padding 1)
                                       :stop (+ padding
                                                seq-length)}
-                                     :left-flank {:start (- (+ padding 1) flank-length)
+                                     :left-flank {:type "flank"
+                                                  :start (- (+ padding 1) flank-length)
                                                   :stop padding}
-                                     :right-flank {:start (+ padding 1 seq-length)
+                                     :right-flank {:type "flank"
+                                                   :start (+ padding 1 seq-length)
                                                    :stop (+
                                                           padding
                                                           seq-length
@@ -234,7 +237,8 @@
 
                                       :features
                                       {:variation
-                                       {:start (:start (:variation (:features wildtype-positive)))
+                                       {:type "variation"
+                                        :start (:start (:variation (:features wildtype-positive)))
                                         :stop (+ (:stop (:variation (:features wildtype-positive)))
                                                  length-change)}
 
@@ -242,7 +246,8 @@
                                        (:left-flank (:features wildtype-positive))
 
                                        :right-flank
-                                       {:start (+ (:start (:right-flank (:features wildtype-positive)))
+                                       {:type "flank"
+                                        :start (+ (:start (:right-flank (:features wildtype-positive)))
                                                   length-change)
                                         :stop (+ (:stop (:right-flank (:features wildtype-positive)))
                                                  length-change)}}})

--- a/src/rest_api/classes/variation/widgets/molecular_details.clj
+++ b/src/rest_api/classes/variation/widgets/molecular_details.clj
@@ -34,10 +34,16 @@
                          (contains? variation :variation-source-location)
                          nil
                          1)
+               refseqobj (sequence-fns/genomic-obj variation)
+               wildtype   (sequence-fns/get-sequence
+                          (conj
+                            refseqobj
+                            {:start (- (:start refseqobj) flank)
+                             :stop (+ flank (:stop refseqobj))}))
                ]
 
            {:ldtype_fragment nil
-            :wildtype_full (seq (:variation/expr-pattern variation))
+            :wildtype_full refseq
             :mutant_fragment nil
             :keys (keys variation)
             :mutant_full nil
@@ -136,22 +142,19 @@
 (defn features-affected [variation]
   {:data (pace-utils/vmap
            "Clone"
-           (some->> (:sequence/clone
-                      (:variation/mapping-target variation))
-                    (map (fn [c]
-                           (conj
-                             (pack-obj c)
-                             {:fstart nil
-                              :fstop nil
-                              :abs_start nil
-                              :abs_stop nil
-                              :start nil
-                              :stop nil
-                              :item (pack-obj c)}
-                           ))
-                    ))
-
-           "Chromosome"
+           (when-let [s  (:variation/mapping-target variation)]
+             (when-let [refseqobj (sequence-fns/genomic-obj s)]
+               [(conj
+                  (pack-obj s)
+                  {:fstart (:start refseqobj)
+                   :keys (keys s)
+                   :fstop (:stop refseqobj)
+                   :abs_start nil
+                   :abs_stop nil
+                   :start nil
+                   :stop nil
+                   :item (pack-obj s)})]))
+          "Chromosome"
            (some->> (:variation/map variation)
                     (map :variation.map/map)
                     (map (fn [m]
@@ -163,13 +166,8 @@
                               :abs_start nil
                               :abs_stop nil
                               :start nil
-                              :stop nil
-                              }
-                             )
+                              :stop nil}))))
 
-                           ) )
-                    
-                    )
            ; commenting out just to save space in output
 ;           "Gene"
 ;           (some->> (:variation/gene variation)
@@ -248,6 +246,7 @@
 ;                                )
 ;                              ))))
            )
+   :d (:db/id variation)
    :description "genomic features affected by this variation"})
 
 (defn cgh-deleted-probes [variation]
@@ -368,20 +367,20 @@
 
 (def widget
   {:name generic/name-field
-;   :polymorphism_type polymorphism-type
-;   :amino_acid_change amino-acid-change
-;   :detection_method detection-method
-;   :deletion_verification deletion-verification
-;   :context context
-;   :flanking_pcr_products flanking-pcr-products
-;   :variation_type variation-type
-;   :features_affected features-affected
-;   :cgh_deleted_probes cgh-deleted-probes
-;   :cgh_flanking_probes cgh-flanking-probes
-;   :polymorphism_assays polymorphism-assays
-;   :affects_splice_site affects-splice-site
-;   :polymorphism_status polymorphism-status
+   :polymorphism_type polymorphism-type
+   :amino_acid_change amino-acid-change
+   :detection_method detection-method
+   :deletion_verification deletion-verification
+   :context context
+   :flanking_pcr_products flanking-pcr-products
+   :variation_type variation-type
+   :features_affected features-affected
+   :cgh_deleted_probes cgh-deleted-probes
+   :cgh_flanking_probes cgh-flanking-probes
+   :polymorphism_assays polymorphism-assays
+   :affects_splice_site affects-splice-site
+   :polymorphism_status polymorphism-status
    :nucleotide_change nucleotide-change
-;   :reference_strain reference-strain
-;   :causes_frameshift causes-frameshift
+   :reference_strain reference-strain
+   :causes_frameshift causes-frameshift
    :sequencing_status sequencing-status})

--- a/src/rest_api/classes/variation/widgets/molecular_details.clj
+++ b/src/rest_api/classes/variation/widgets/molecular_details.clj
@@ -345,7 +345,7 @@
                             :variation/confirmed-snp "Confirmed SNP"
                             :variation/reference-strain-digest "RFLP"
                             :variation/predicted-snp "Predicted SNP"
-                            :variation/transposon-linsertion "Transposon Insertion"
+                            :variation/transposon-insertion "Transposon Insertion"
                             :variation/natural-variant "Natural Variant"}
         type-of-mutation-map {:variation/substitution "Substitution"
                               :variation/insertion "Insertion"

--- a/src/rest_api/classes/variation/widgets/molecular_details.clj
+++ b/src/rest_api/classes/variation/widgets/molecular_details.clj
@@ -127,8 +127,9 @@
                   (map (fn [pcdsh]
                         (when (contains? pcdsh :molecular-change/missense) ;add case for nonsense if we get the truncated sequence in the database in the future. (e.g. WBVar00466445)
                          {:amino_acid_change (:aa_change (get-missense-obj pcdsh))
-                          :transcript (pack-obj (:variation.predicted-cds/cds pcdsh))}
-                         ))))
+                          :transcript (pack-obj (:variation.predicted-cds/cds pcdsh))})))
+                  (remove nil?)
+                  (not-empty))
    :description "amino acid changes for this variation, if appropriate"})
 
 (defn detection-method [variation] ; WBVar00601206

--- a/src/rest_api/classes/variation/widgets/molecular_details.clj
+++ b/src/rest_api/classes/variation/widgets/molecular_details.clj
@@ -3,6 +3,7 @@
     [datomic.api :as d]
     [clojure.string :as str]
     [rest-api.db.sequence :as seqdb]
+    [rest-api.classes.sequence.core :as sequence-fns]
     [rest-api.classes.generic-fields :as generic]
     [rest-api.classes.generic-functions :as generic-functions]
     [pseudoace.utils :as pace-utils]
@@ -16,8 +17,8 @@
   {:data nil
    :description "amino acid changes for this variation, if appropriate"})
 
-(defn detection-method [variation]
-  {:data nil
+(defn detection-method [variation] ; WBVar00601206
+  {:data (first (:variation/detection-method variation))
    :description "detection method for polymorphism, typically via sequencing or restriction digest."})
 
 (defn deletion-verification [variation]
@@ -56,14 +57,15 @@
                             :variation/allele"Allele"
                             :variation/snp "SNP"
                             :variation/confirmed-snp "Confirmed SNP"
+                            :variation/reference-strain-digest "RFLP"
                             :variation/predicted-snp "Predicted SNP"
                             :variation/transposon-insertion "Transposon Insertion"
                             :variation/natural-variant "Natural Variant"}
         type-of-mutation-map {:variation/substitution "Substitution"
                               :variation/insertion "Insertion"
-                              :variation/detetion "Deletion"
+                              :variation/deletion "Deletion"
                               :variation/tandem-duplication "Tandem Duplication"}]
-    {:data {:pysical_class (cond
+    {:data {:physical_class (cond
                              (contains? variation :variation/transposon-insertion)
                              "Transposon insertion"
 
@@ -81,7 +83,7 @@
             :general_class (->> variation-type-map
                                 (map
                                   #(str (if
-                                          (true? ((first %) variation))
+                                          (contains? variation (first %))
                                           (second %))))
                                 (filter #(not= % "")))}
      :description "the general type of the variation"}))
@@ -130,60 +132,121 @@
         ]
     nil))
 
-;test WBVar01112111/
+;test WBVar01112111 WBVar00601206
 (defn features-affected [variation]
   {:data (pace-utils/vmap
            "Clone"
-           nil
+           (some->> (:sequence/clone
+                      (:variation/mapping-target variation))
+                    (map (fn [c]
+                           (conj
+                             (pack-obj c)
+                             {:fstart nil
+                              :fstop nil
+                              :abs_start nil
+                              :abs_stop nil
+                              :start nil
+                              :stop nil
+                              :item (pack-obj c)}
+                           ))
+                    ))
 
            "Chromosome"
-           nil
+           (some->> (:variation/map variation)
+                    (map :variation.map/map)
+                    (map (fn [m]
+                           (conj
+                             (pack-obj m)
+                             {:item (pack-obj m)
+                              :fstart nil
+                              :fstop nil
+                              :abs_start nil
+                              :abs_stop nil
+                              :start nil
+                              :stop nil
+                              }
+                             )
 
-           "Gene"
-           (->>
-             (:variation/gene variation)
-             (map-indexed
-               (fn [idx gh]
-                 (let [gene (:variation.gene/gene gh)
-                       obj (pack-obj gene)]
-                   {:entry (+ idx 1)
-                    :item obj
-                    :id (:gene/id gene)
-                    :label (:label obj)
-                    :class "gene"
-                    :taxonomy (:taxonomy obj)}))))
+                           ) )
+                    
+                    )
+           ; commenting out just to save space in output
+;           "Gene"
+;           (some->> (:variation/gene variation)
+;                (map-indexed
+;                  (fn [idx gh]
+;                    (let [gene (:variation.gene/gene gh)
+;                          obj (pack-obj gene)]
+;                      {:entry (+ idx 1)
+;                       :item obj
+;                       :id (:gene/id gene)
+;                       :label (:label obj)
+;                       :class "gene"
+;                       :taxonomy (:taxonomy obj)}))))
 
            "Predicted_CDS"
-           (->>
-             (:variation/predicted-cds variation)
-             (map
-               (fn [predicted-cds-holder]
-                 (pace-utils/vmap
-                   :protein_effects
-                   (pace-utils/vmap
-                     "Silent"
-                     (if-let [cdshs (:molecular-change/missense predicted-cds-holder)]
-                       (for [cdsh cdshs :let [position (first cdsh)
-                                              description (second cdsh)
-                                              cds (:variation.predicted-cds/cds cdsh)]]
-                         (if-let [wt-protein (:cds/corresponding-protein cdsh)]
-                           (if-let  [wt-peptide (:protein/peptide wt-protein)]
-                             (let [formatted-wt-peptide (str/replace wt-peptide #"[^>|\n]" "")
-                                   [wt-aa mut_aa] (re-seq #"(?s) to (?s)" description)
-                                   mut-peptide (str/join
-                                                 (assoc
-                                                   (vec formatted-wt-peptide) (- position 1) mut_aa))
-                                   wt-protein-fragment (create-fragment wt-peptide position)
-                                   mut-protein-fragment (create-fragment mut-peptide position)
-                                   ]
-                               {:wildtype_conceptual_translation nil
-                                :mutant_conceptual_translation nil
-                                }))))))
+           (some->> (:variation/predicted-cds variation)
+                (map
+                  (fn [predicted-cds-holder]
+                    (pace-utils/vmap
+                      :protein_effects
+                      (pace-utils/vmap
+                        "Silent"
+                        (if-let [cdshs (:molecular-change/missense predicted-cds-holder)]
+                          (for [cdsh cdshs :let [position (first cdsh)
+                                                 description (second cdsh)
+                                                 cds (:variation.predicted-cds/cds cdsh)]]
+                            (if-let [wt-protein (:cds/corresponding-protein cdsh)]
+                              (if-let  [wt-peptide (:protein/peptide wt-protein)]
+                                (let [formatted-wt-peptide (str/replace wt-peptide #"[^>|\n]" "")
+                                      [wt-aa mut_aa] (re-seq #"(?s) to (?s)" description)
+                                      mut-peptide (str/join
+                                                    (assoc
+                                                      (vec formatted-wt-peptide) (- position 1) mut_aa))
+                                      wt-protein-fragment (create-fragment wt-peptide position)
+                                      mut-protein-fragment (create-fragment mut-peptide position)
+                                      ]
+                                  {:wildtype_conceptual_translation nil
+                                   :mutant_conceptual_translation nil
+                                   }))))))
 
-                   :location_effects nil
-                   )))
-             )
-
+                      :location_effects nil
+                      ))))
+;
+;            "Transcript"
+;            (some->> (:variation/transcript variation)
+;                     (map (fn [h]
+;                            (let [t (:variation.transcript/transcript h)]
+;                              (when-let  [refseqobj  (sequence-fns/genomic-obj t)]
+;                            (conj
+;                              (pack-obj t)
+;                              {:item (pack-obj t)
+;                               :fstart (:start refseqobj)
+;                               :fstop (:stop refseqobj)
+;                               :start nil
+;                               :abs_stop nil
+;                               :location_effects {:UTR_5 (let [fpu (:molecular-change/five-prime-utr h)
+;                                                               ev (obj/get-evidence fpu)]
+;                                                           {:evidence_type (some->> ev vals flatten first)
+;                                                            :evidence (some->> ev keys first)})
+;                                                  :UTR_3 (let [fpu (:molecular-change/three-prime-utr h)
+;                                                               ev (obj/get-evidence fpu)]
+;                                                           {:evidence_type (some->> ev vals flatten first)
+;                                                            :evidence (some->> ev keys first)})}}))))))
+;
+;            "Pseudogene"
+;            (some->> (:variation/pseudogene variation)
+;                     (map :variation.pseudogene/pseudogene)
+;                     (map (fn [pseudogene]
+;                            (when-let [refseqobj (sequence-fns/genomic-obj pseudogene)]
+;                              (conj
+;                                (pack-obj pseudogene)
+;                                {:fstart (:start refseqobj)
+;                                 :fstop (:stop refseqobj)}
+;                                {:item (pack-obj pseudogene)
+;                                 }
+;                                )
+;                              ))))
            )
    :description "genomic features affected by this variation"})
 
@@ -204,8 +267,13 @@
           :acceptor nil}
    :description "Affects splice site"})
 
-(defn polymorphism-status [variation]
-  {:data nil
+(defn polymorphism-status [variation]; WBVar00116162 is predicted
+  {:data (if (contains? variation :variation/confirmed-snp)
+           "confirmed"
+           (if (or (contains? variation :variation/snp)
+                   (or (contains? variation :variation/reference-strain-digest)
+                       (contains? variation :variation/transposon-insertion)))
+             "predicted"))
    :description "experimental status of this polymorphism"})
 
 (defn- pack-nulcleotide-change-obj [type-str wildtype mutant]
@@ -213,8 +281,7 @@
    :wildtype wildtype
    :mutant mutant
    :wildtype-label "wildtype"
-   :mutant-label "variant"}
-  )
+   :mutant-label "variant"})
 
 (defn- reverse-complement [dna]
   (str/replace
@@ -238,7 +305,7 @@
       (if sequence-database
         (seqdb/variation-features db-spec variation-id)))))
 
-(defn- compile-nucleotide-changes [variation]
+(defn- compile-nucleotide-changes [variation] ;WBVar00116162 substitution
   (remove nil?
           [
            (if-let [insertion (:variation/insertion variation)]
@@ -251,30 +318,35 @@
              nil
              )
            (if-let [substitution (:variation/substitution variation)]
-             (if-let [mut (:variation.substitution/ref substitution)]
-               (let [features (variation-features variation)]
-                 (println (str (seq (:object (first features)))))
-                 (if-let [feature (first features)]
-                   (let [wt (:variation.substitution/alt substitution)
-                         plus-strand-dna (:object feature)
-                         uc-plus-strand-dna (do (println plus-strand-dna)
-                                                (str/upper-case plus-strand-dna))]
-                     (if (not= (str/upper-case wt) uc-plus-strand-dna)
-                       (let [rc-wt (reverse-complement wt)]
-                         (println rc-wt)
-                         (println uc-plus-strand-dna)
-                         (if (= (str/upper-case rc-wt) uc-plus-strand-dna)
-                           (pack-nulcleotide-change-obj )
-                           {:wt rc-wt
-                            :dbid (:db/id variation)
-                            :mut (reverse-complement mut)}))))))
-
-               ))]))
+             (if-let [ref-allele (:variation.substitution/ref substitution)]
+               (let [fs (:variation/flanking-sequences variation)
+                     five-prime (:variation.flanking-sequences/five-prime fs)
+                     three-prime (:variation.flanking-sequences/three-prime fs)
+                     ]
+                 five-prime)
+ ;              (let [features (variation-features variation)]
+;                 (println (str (seq (:object (first features)))))
+;                 (if-let [feature (first features)]
+;                   (let [wt (:variation.substitution/alt substitution)
+;                         plus-strand-dna (:object feature)
+;                         uc-plus-strand-dna (do (println plus-strand-dna)
+;                                                (str/upper-case plus-strand-dna))]
+;                     (if (not= (str/upper-case wt) uc-plus-strand-dna)
+;                       (let [rc-wt (reverse-complement wt)]
+;                         (println rc-wt)
+;                         (println uc-plus-strand-dna)
+;                         (if (= (str/upper-case rc-wt) uc-plus-strand-dna)
+;                           (pack-nulcleotide-change-obj )
+;                           {:wt rc-wt
+;                            :dbid (:db/id variation)
+;                            :mut (reverse-complement mut)}))))))
+;)
+              )) ]))
 
 
 (defn nucleotide-change [variation]
-  {:data  nil ;(compile-nucleotide-changes variation)
-   :keys (keys variation)
+  {:data (compile-nucleotide-changes variation)
+   :d (:db/id variation)
    :description "raw nucleotide changes for this variation"})
 
 ;tested with WBVar00101112
@@ -296,20 +368,20 @@
 
 (def widget
   {:name generic/name-field
-   :polymorphism_type polymorphism-type
-   :amino_acid_change amino-acid-change
-   :detection_method detection-method
-   :deletion_verification deletion-verification
-   :context context
-   :flanking_pcr_products flanking-pcr-products
-   :variation_type variation-type
-   :features_affected features-affected
-   :cgh_deleted_probes cgh-deleted-probes
-   :cgh_flanking_probes cgh-flanking-probes
-   :polymorphism_assays polymorphism-assays
-   :affects_splice_site affects-splice-site
-   :polymorphism_status polymorphism-status
+;   :polymorphism_type polymorphism-type
+;   :amino_acid_change amino-acid-change
+;   :detection_method detection-method
+;   :deletion_verification deletion-verification
+;   :context context
+;   :flanking_pcr_products flanking-pcr-products
+;   :variation_type variation-type
+;   :features_affected features-affected
+;   :cgh_deleted_probes cgh-deleted-probes
+;   :cgh_flanking_probes cgh-flanking-probes
+;   :polymorphism_assays polymorphism-assays
+;   :affects_splice_site affects-splice-site
+;   :polymorphism_status polymorphism-status
    :nucleotide_change nucleotide-change
-   :reference_strain reference-strain
-   :causes_frameshift causes-frameshift
+;   :reference_strain reference-strain
+;   :causes_frameshift causes-frameshift
    :sequencing_status sequencing-status})

--- a/src/rest_api/db/sql/sequence.sql
+++ b/src/rest_api/db/sql/sequence.sql
@@ -46,7 +46,7 @@ AND (t.tag LIKE "transcript%"
 
 -- :name variation-features :? :*
 -- :doc Retrieve all sequences for a gene by ida
-SELECT f.id,CONVERT(f.object USING utf8),f.typeid,f.seqid,l.seqname,f.start,f.end,f.strand
+SELECT f.id,f.typeid,f.seqid,l.seqname,f.start,f.end,f.strand
 FROM feature as f
 JOIN attribute as a ON a.id=f.id
 JOIN locationlist as l on l.id=f.seqid


### PR DESCRIPTION
This pull request contains the variation molecular details widget. I have left comments in the code indicating which variations were used to test/compare with that which is on staging. 

The current plan is to get the curators to test this endpoint. I will fix anything that they find and then it will be rolled out into production. If we roll out WS268 before this widget is ready we will comment it out in production.