### PR TITLE
Fix/269 paper author

### DIFF
--- a/src/rest_api/classes/gene/widgets/mapping_data.clj
+++ b/src/rest_api/classes/gene/widgets/mapping_data.clj
@@ -23,7 +23,7 @@
      [?mc :multi-counts/gene ?mc2]]])
 
 (defn- twopt-item [tp]
-  {:mapper (pack-obj "author" (first (:two-point-data/mapper tp)))
+  {:mapper (pack-obj (first (:two-point-data/mapper tp)))
    :date (if (:two-point-data/date tp)
            (dates/format-date (:two-point-data/date tp)))
    :raw_data (:two-point-data/results tp)
@@ -94,7 +94,7 @@
         result (when-let [pn-results (:pos-neg-data/results pn)]
                  (str/split pn-results #"\s+"))]
     {:mapper (when-first [m (seq (:pos-neg-data/mapper pn))]
-               (pack-obj "author" m))
+               (pack-obj m))
      :comment (let [comment (str/join "<br>"
                                       (map :pos-neg-data.remark/text
                                            (:pos-neg-data/remark pn)))]
@@ -156,7 +156,7 @@
                                first
                                :multi-pt-data.remark/text)]
               (if (empty? comment) "" comment))
-   :mapper (pack-obj "author" (first (:multi-pt-data/mapper mp)))
+   :mapper (pack-obj (first (:multi-pt-data/mapper mp)))
    :date (if-let [mp-date (:multi-pt-data/date mp)]
            (dates/format-date3 (str mp-date))
            "")

--- a/src/rest_api/classes/paper/core.clj
+++ b/src/rest_api/classes/paper/core.clj
@@ -26,9 +26,7 @@
              :let [author (:paper.author/author h)
                    person (first (:affiliation/person h))]]
          {(:ordered/index h)
-          {:id (or (:person/id person)
-                   (:author/id author))
-           :class (cond person "person"
-                        author "author")
-           :label (:author/id author)
-           :taxonomy "all"}}))))))
+          (if person
+            (-> (obj/pack-obj person)
+                (assoc :label (:author/id author)))
+            (obj/pack-obj author))}))))))

--- a/src/rest_api/classes/paper/core.clj
+++ b/src/rest_api/classes/paper/core.clj
@@ -14,33 +14,21 @@
               ""
               (first (str/split (:paper/publication-date paper)
                                 #"-"))))})
+
 (defn get-authors [p]
   (when-let [hs (:paper/author p)]
-           (vals
-             (into
-               (sorted-map)
-               (into
-                 {}
-                 (for [h hs
-                       :let [author (cond
-                                      (contains? h :affiliation/person)
-                                      (first (:affiliation/person h))
-
-                                      (contains? h :paper.author/author)
-                                      (:paper.author/author h))]]
-                   {(:ordered/index h)
-                      {:id (or (:author/id author)
-                               (:person/id author))
-                       :class "author"
-                       :label (if (:person/id author)
-                                (let [lastname (:person/last-name author)
-                                      first-initial (when-let [firstname (:person/first-name author)]
-                                                      (str/capitalize (get firstname 0)))]
-                                  (if-let [middlenames (:person/middle-name author)]
-                                    (let [middle-initials (map (fn [middlename] (str (str/capitalize (get middlename 0)))) middlenames)
-                                          middle-initials-str (str/join ". " middle-initials)]
-                                      (str lastname ", " first-initial ". " middle-initials-str "."))
-                                    (str lastname ", " first-initial ".")))
-                                (if-let [[lastname initial] (str/split (:author/id author) #" ")]
-                                  (str lastname ", " initial ".")))
-                       :taxonomy "all"}}))))))
+    (vals
+     (into
+      (sorted-map)
+      (into
+       {}
+       (for [h hs
+             :let [author (:paper.author/author h)
+                   person (first (:affiliation/person h))]]
+         {(:ordered/index h)
+          {:id (or (:person/id person)
+                   (:author/id author))
+           :class (cond person "person"
+                        author "author")
+           :label (:author/id author)
+           :taxonomy "all"}}))))))

--- a/src/rest_api/formatters/object.clj
+++ b/src/rest_api/formatters/object.clj
@@ -132,6 +132,9 @@
      (or (:author/id (first (:person/possibly-publishes-as person)))
          (:person/id person))))
 
+(defmethod obj-label "author" [_ author]
+  (:author/id author))
+
 (defmethod obj-label "construct" [_ cons]
   (or (first (:construct/public-name cons))
       (or (first (:construct/other-name cons))
@@ -271,9 +274,7 @@
                       (:oligo/id obj))))
       :label (or label (obj-label class obj))
       :class (if class
-               (if (= class "author")
-                 "person"
-                 (str/replace class "-" "_")))
+               (str/replace class "-" "_"))
       :taxonomy (obj-tax class obj)}))
 
 (defmulti pack-obj-helper
@@ -340,7 +341,7 @@
    :Author_evidence
    (seq (for [ah (:evidence/author-evidence holder)
               :let [author (:evidence.author-evidence/author ah)]]
-          {:evidence (pack-obj "author" author)}))
+          {:evidence (pack-obj author)}))
 
    :Accession_evidence
    (when-let [accs (:evidence/accession-evidence holder)]

--- a/src/rest_api/formatters/object.clj
+++ b/src/rest_api/formatters/object.clj
@@ -75,31 +75,24 @@
       (:variation/id obj)))
 
 ;; Helpers for paper labels.
-(defn- author-lastname [author-holder]
-  (or
-   (->> (:affiliation/person author-holder)
-        (first)
-        (:person/last-name))
-   (-> (:paper.author/author author-holder)
-       (:author/id)
-       (.trim)
-       (str/split #"\s+")
-       (first))))
+(defn- author-name [author-holder]
+  (-> (:paper.author/author author-holder)
+      (:author/id)))
 
 (defn author-list [paper]
   (let [authors (sort-by :ordered/index (:paper/author paper))]
     (cond
      (= (count authors) 1)
-     (author-lastname (first authors))
+     (author-name (first authors))
 
      (< (count authors) 6)
-     (let [last-names (map author-lastname authors)]
-       (str (str/join ", " (butlast last-names))
+     (let [names (map author-name authors)]
+       (str (str/join ", " (butlast names))
             " & "
-            (last last-names)))
+            (last names)))
 
      :default
-     (str (author-lastname (first authors)) " et al."))))
+     (str (author-name (first authors)) " et al."))))
 
 (defmethod obj-label "paper" [_ paper]
   (if (contains? paper :paper/author)

--- a/src/rest_api/formatters/object.clj
+++ b/src/rest_api/formatters/object.clj
@@ -122,8 +122,7 @@
 
 (defmethod obj-label "person" [_ person]
  (or (:person/standard-name person)
-     (or (:author/id (first (:person/possibly-publishes-as person)))
-         (:person/id person))))
+     (:person/id person)))
 
 (defmethod obj-label "author" [_ author]
   (:author/id author))


### PR DESCRIPTION
relates to WormBase/website#6802

- differentiate author and person in pack-obj
- use :author/id as label when displaying author names for a paper