### PR TITLE
Feature/feature molecular details

### DIFF
--- a/src/rest_api/classes/feature.clj
+++ b/src/rest_api/classes/feature.clj
@@ -14,6 +14,6 @@
    {:overview overview/widget
     :history history/widget
     :associations associations/widget
-    ;:molecular_details molecular-details/widget
+    :molecular_details molecular-details/widget
     :evidence evidence/widget
     :location location/widget}})

--- a/src/rest_api/classes/feature/widgets/molecular_details.clj
+++ b/src/rest_api/classes/feature/widgets/molecular_details.clj
@@ -1,21 +1,85 @@
 (ns rest-api.classes.feature.widgets.molecular-details
   (:require
+    [clojure.string :as str]
+    [rest-api.classes.sequence.core :as sequence-fns]
     [rest-api.formatters.object :as obj :refer  [pack-obj]]
     [rest-api.classes.generic-fields :as generic]))
 
+(defn- reverse-complement [dna]
+  (str/replace
+    (str/reverse dna)
+    #"A|C|G|T|a|c|g|t"
+    {"A" "T"
+     "C" "G"
+     "G" "C"
+     "T" "A"
+     "a" "t"
+     "c" "g"
+     "g" "c"
+     "t" "a"
+     "-" "-"}))
+
 (defn flanking-sequences [f]
-  {:data {:flanks [(:feature.flanking-sequences/five-prime (:feature/flanking-sequences f))
-                   (:feature.flanking-sequences/three-prime (:feature/flanking-sequences f))]
-          :feture_seq nil
-          :seq nil 
-          :sequences  [{:sequence (:feature.flanking-sequences/five-prime (:feature/flanking-sequences f))
-                        :comment "flanking sequence (upstream)"}
-                       {:sequence (:feature.flanking-sequences/three-prime (:feature/flanking-sequences f))
-                        :comment "flanking sequence (downstream)"}]}
+  {:data (when-let [s (:locatable/parent f)]
+           (let [five-prime-flank (:feature.flanking-sequences/five-prime (:feature/flanking-sequences f))
+                 three-prime-flank (:feature.flanking-sequences/three-prime (:feature/flanking-sequences f))
+                 flanks [five-prime-flank three-prime-flank]
+                 seq-obj (pack-obj s)
+                 method (-> f :locatable/method :method/id)]
+             (if (or (some #(= method %) ["SL1" "SL2" "polyA_site" "history feature"])
+                     (not (contains? f :locatable/min)))
+               {:flanks flanks  ; section tested with WBsf000519
+                :seq seq-obj
+                :sequences [{:sequence five-prime-flank
+                             :comment "flanking sequence (upstream)"}
+                            {:sequence three-prime-flank
+                             :comment "flanking sequence (downstream)"}]})
+             (let [feature-start (:locatable/min f) ;tested with WBsf019129
+                   feature-end (:locatable/max f)
+                   padding 30
+                   refseqobj (sequence-fns/genomic-obj f)
+                   s (sequence-fns/get-sequence
+                       (conj
+                         refseqobj
+                         {:start (- (:start refseqobj) padding)
+                          :stop (+ padding (:stop refseqobj))}))
+                   padding-start (if (> (count five-prime-flank) padding)
+                                   (subs five-prime-flank padding)
+                                   five-prime-flank)
+                   padding-end (if (> (count three-prime-flank) padding)
+                                 (subs three-prime-flank
+                                       (- (count three-prime-flank) padding)
+                                       (count three-prime-flank))
+                                 three-prime-flank)
+                   strand (if (and (str/includes? s padding-start)
+                                   (str/includes? s padding-end))
+                            "positive" "negative")
+                   processed-sequence (if (= strand "negative")
+                                        (reverse-complement s)
+                                        s)
+                   feature-seq (str/upper-case
+                                 (subs
+                                   processed-sequence
+                                   padding
+                                   (- (count processed-sequence) padding)))]
+               {:flanks flanks
+                :feature_seq feature-seq
+                :seq seq-obj
+                :dna-seq feature-seq
+                :sequences [{:sequence (str/replace
+                                         processed-sequence
+                                         (subs processed-sequence
+                                               padding
+                                               (- (count processed-sequence) padding))
+                                         feature-seq)
+                             :comment (str "upper case: feature sequence; lower case: flanking sequences (" strand ")")
+                             :higlight
+                             {:offset padding
+                              :length (count feature-seq)}}]})))
    :description "sequences flanking the feature"})
 
-(defn dna-text [f]
-  {:data nil
+(defn dna-text [f] ; tested with WBsf019129
+  {:data (:feature/dna-text f)
    :description "DNA text of the sequence feature"})
 
 (def widget

--- a/src/rest_api/classes/feature/widgets/molecular_details.clj
+++ b/src/rest_api/classes/feature/widgets/molecular_details.clj
@@ -3,21 +3,9 @@
     [clojure.string :as str]
     [rest-api.classes.sequence.core :as sequence-fns]
     [rest-api.formatters.object :as obj :refer  [pack-obj]]
+    [rest-api.classes.generic-functions :as generic-functions]
     [rest-api.classes.generic-fields :as generic]))
 
-(defn- reverse-complement [dna]
-  (str/replace
-    (str/reverse dna)
-    #"A|C|G|T|a|c|g|t"
-    {"A" "T"
-     "C" "G"
-     "G" "C"
-     "T" "A"
-     "a" "t"
-     "c" "g"
-     "g" "c"
-     "t" "a"
-     "-" "-"}))
 
 (defn flanking-sequences [f]
   {:data (when-let [s (:locatable/parent f)]
@@ -55,7 +43,7 @@
                                    (str/includes? s padding-end))
                             "positive" "negative")
                    processed-sequence (if (= strand "negative")
-                                        (reverse-complement s)
+                                        (generic-functions/reverse-complement s)
                                         s)
                    feature-seq (str/upper-case
                                  (subs
@@ -73,7 +61,7 @@
                                                (- (count processed-sequence) padding))
                                          feature-seq)
                              :comment (str "upper case: feature sequence; lower case: flanking sequences (" strand ")")
-                             :higlight
+                             :highlight
                              {:offset padding
                               :length (count feature-seq)}}]})))
    :description "sequences flanking the feature"})

--- a/src/rest_api/classes/generic_functions.clj
+++ b/src/rest_api/classes/generic_functions.clj
@@ -4,6 +4,21 @@
     [rest-api.formatters.object :as obj :refer [pack-obj]]
     [clojure.string :as str]))
 
+(defn reverse-complement [dna]
+  (str/replace
+    (str/reverse dna)
+    #"A|C|G|T|a|c|g|t"
+    {"A" "T"
+     "C" "G"
+     "G" "C"
+     "T" "A"
+     "a" "t"
+     "c" "g"
+     "g" "c"
+     "t" "a"
+     "-" "-"}))
+
+
 (defn xform-species-name
   "Transforms a `species-name` from the WB database into
   a name used to look up connection configuration to a sequence db."

--- a/src/rest_api/classes/variation/widgets/molecular_details.clj
+++ b/src/rest_api/classes/variation/widgets/molecular_details.clj
@@ -213,21 +213,7 @@
    :wildtype wildtype
    :mutant mutant
    :wildtype-label "wildtype"
-   :mutant-label "variant"}
-  )
-
-(defn- reverse-complement [dna]
-  (str/replace
-    (str/reverse dna)
-    #"A|C|G|T|a|c|g|t"
-    {"A" "T"
-     "C" "G"
-     "G" "C"
-     "T" "A"
-     "a" "t"
-     "c" "g"
-     "g" "c"
-     "t" "a"}))
+   :mutant-label "variant"})
 
 (defn- variation-features [variation]
   (if-let  [species-name (->> variation :variation/species :species/id)]
@@ -260,16 +246,15 @@
                          uc-plus-strand-dna (do (println plus-strand-dna)
                                                 (str/upper-case plus-strand-dna))]
                      (if (not= (str/upper-case wt) uc-plus-strand-dna)
-                       (let [rc-wt (reverse-complement wt)]
+                       (let [rc-wt (generic-functions/reverse-complement wt)]
                          (println rc-wt)
                          (println uc-plus-strand-dna)
                          (if (= (str/upper-case rc-wt) uc-plus-strand-dna)
                            (pack-nulcleotide-change-obj )
                            {:wt rc-wt
                             :dbid (:db/id variation)
-                            :mut (reverse-complement mut)}))))))
-
-               ))]))
+                            :mut (generic-functions/reverse-complement mut)}))))))
+        ))]))
 
 
 (defn nucleotide-change [variation]


### PR DESCRIPTION
This widget had been tested with two main Features: WBsf000519 and WBsf019129. The intention is to have this widget to be consistent with the variation molecular details widget. 

The first feature listed above (WBsf000519) is an example of a feature where we do not have the sequence. And the second feature (WBsf019129) is an example of a feature where we are to be displaying the sequence. For these features, I am returning the method. I think most of them have a method. This would likely be interesting to the user. 

I have included code to figure out the strand of the feature and am returning the strand in the JSON. I think it would be nice to make this clear to the user. I am not sure if it is always positive but either way it should be clear.