### PR TITLE
Feature/transcript cds fixes

### DIFF
--- a/src/rest_api/classes/cds.clj
+++ b/src/rest_api/classes/cds.clj
@@ -16,7 +16,7 @@
    {:overview overview/widget
     :location location/widget
     :feature feature/widget
-    ;:sequences sequences/widget
+    :sequences sequences/widget
     :reagents reagents/widget
     :external_links external-links/widget
     :references references/widget}

--- a/src/rest_api/classes/cds/widgets/overview.clj
+++ b/src/rest_api/classes/cds/widgets/overview.clj
@@ -7,7 +7,6 @@
 
 (defn description [cds]
   {:data (:cds.detailed-description/text (first (:cds/detailed-description cds)))
-   :d (:db/id cds)
    :description (str "description of the CDS " (:cds/id cds))})
 
 (defn partial-field [cds]

--- a/src/rest_api/classes/cds/widgets/sequences.clj
+++ b/src/rest_api/classes/cds/widgets/sequences.clj
@@ -7,20 +7,12 @@
     [rest-api.classes.generic-functions :as generic-functions]
     [rest-api.formatters.object :as obj :refer [pack-obj]]))
 
-(defn unspliced-sequence-context [c]
+(defn cds-sequence [c]
   {:data (when-let [transcript  (-> c
                                     :transcript.corresponding-cds/_cds
                                     first
                                     :transcript/_corresponding-cds)]
-          (sequence-fns/transcript-sequence-features transcript 0 "unspliced"))
-   :description "the unpliced sequence of the sequence"})
-
-(defn spliced-sequence-context [c]
-  {:data (when-let [transcript  (-> c
-                                    :transcript.corresponding-cds/_cds
-                                    first
-                                    :transcript/_corresponding-cds)]
-          (sequence-fns/transcript-sequence-features transcript 0 "spliced"))
+          (sequence-fns/transcript-sequence-features transcript 0 :cds))
    :description "the unpliced sequence of the sequence"})
 
 (defn protein-sequence [c]
@@ -46,9 +38,6 @@
 
 (def widget
   {:name generic/name-field
-   :predicted_exon_structure generic/predicted-exon-structure
    :print_blast print-blast
    :protein_sequence protein-sequence
-   :predicted_unit generic/predicted-units
-   :unspliced_sequence_context unspliced-sequence-context
-   :spliced_sequence_context spliced-sequence-context})
+   :cds_sequence cds-sequence})

--- a/src/rest_api/classes/cds/widgets/sequences.clj
+++ b/src/rest_api/classes/cds/widgets/sequences.clj
@@ -13,7 +13,7 @@
                                     first
                                     :transcript/_corresponding-cds)]
           (sequence-fns/transcript-sequence-features transcript 0 :cds))
-   :description "the unpliced sequence of the sequence"})
+   :description "the spliced sequence of the transcripts without UTR"})
 
 (defn protein-sequence [c]
   {:data (when-let [peptide (some->> (:cds/corresponding-protein c)

--- a/src/rest_api/classes/cds/widgets/sequences.clj
+++ b/src/rest_api/classes/cds/widgets/sequences.clj
@@ -8,10 +8,12 @@
     [rest-api.formatters.object :as obj :refer [pack-obj]]))
 
 (defn cds-sequence [c]
-  {:data (when-let [transcript  (-> c
+  {:data (when-let [transcript  (or
+                                 (-> c
                                     :transcript.corresponding-cds/_cds
                                     first
-                                    :transcript/_corresponding-cds)]
+                                    :transcript/_corresponding-cds)
+                                 c)]
           (sequence-fns/transcript-sequence-features transcript 0 :cds))
    :description "the spliced sequence of the transcripts without UTR"})
 

--- a/src/rest_api/classes/generic_fields.clj
+++ b/src/rest_api/classes/generic_fields.clj
@@ -89,9 +89,7 @@
                                  [(some->> (:cds.corresponding-protein/_protein object)
                                            (map :cds/_corresponding-protein)
                                            (filter #(not= "history" (:method/id (:locatable/method %))))
-              ;                             (map :gene.corresponding-cds/_cds)
                                            first)
-               ;                            (map :gene/_corresponding-cds))
                                   "gene"]
 
                                  :else
@@ -157,8 +155,7 @@
              (when-let [position (sequence-fns/genomic-obj object)]
                [position]))
      :description "The genomic location of the sequence"}))
-              ;        (map :gene/_corresponding-cds)
-;                      (map sequence-fns/genomic-obj))
+
 (defn microarray-assays [object]
   {:data (some->> (:locatable/_parent object)
                   (map (fn [f]

--- a/src/rest_api/classes/generic_fields.clj
+++ b/src/rest_api/classes/generic_fields.clj
@@ -151,8 +151,7 @@
                       (map :cds/_corresponding-protein)
                       (filter #(not= "history"  (:method/id  (:locatable/method %))))
                       (first)
-                      (sequence-fns/genomic-obj))
-
+                      (sequence-fns/genomic-obj))]
              (when-let [position (sequence-fns/genomic-obj object)]
                [position]))
      :description "The genomic location of the sequence"}))

--- a/src/rest_api/classes/generic_fields.clj
+++ b/src/rest_api/classes/generic_fields.clj
@@ -536,19 +536,33 @@
                                  (corresponding-all-gene gene object role nil))))
 
                  "cds"
-                 (when-let [ths (:transcript.corresponding-cds/_cds object)]
-                   (let [genes
-                         (distinct
-                           (flatten
-                             (for [th ths
-                                   :let [ghs (:gene.corresponding-transcript/_transcript
-                                               (:transcript/_corresponding-cds th))]]
-                               (for [gh ghs
-                                     :let [gene (:gene/_corresponding-transcript gh)]]
-                                 gene))))]
-                     (flatten
-                       (for [gene genes]
-                         (corresponding-all-gene gene object role nil)))))
+                 (or
+                   (when-let [ths (:transcript.corresponding-cds/_cds object)]
+                     (let [genes
+                           (distinct
+                             (flatten
+                               (for [th ths
+                                     :let [ghs (:gene.corresponding-transcript/_transcript
+                                                 (:transcript/_corresponding-cds th))]]
+                                 (for [gh ghs
+                                       :let [gene (:gene/_corresponding-transcript gh)]]
+                                   gene))))]
+                       (flatten
+                         (for [gene genes]
+                           (corresponding-all-gene gene object role nil)))))
+                   (when-let [ths (:transposon.corresponding-cds/_cds object)]
+                     (let [genes
+                           (distinct
+                             (flatten
+                               (for [th ths
+                                     :let [ghs (:gene.corresponding-transposon/_transposon
+                                                 (:transposon/_corresponding-cds th))]]
+                                 (for [gh ghs
+                                       :let [gene (:gene/_corresponding-transposon gh)]]
+                                   gene))))]
+                       (flatten
+                         (for [gene genes]
+                           (corresponding-all-gene gene object role nil))))))
 
                  "protein" ;; need to make it filter for only the row with the protein
                  (when-let [cdshs (:cds.corresponding-protein/_protein object)]

--- a/src/rest_api/classes/pseudogene.clj
+++ b/src/rest_api/classes/pseudogene.clj
@@ -17,7 +17,7 @@
     :feature feature/widget
     :genetics genetics/widget
     :reagents reagents/widget
-    ;:sequences sequences/widget
+    :sequences sequences/widget
     :expression expression/widget
     :location location/widget
     }

--- a/src/rest_api/classes/pseudogene/widgets/sequences.clj
+++ b/src/rest_api/classes/pseudogene/widgets/sequences.clj
@@ -12,7 +12,7 @@
            (name strand-kw))
    :description "strand orientation of the sequence"})
 
-(defn print-sequence [p]
+(defn sequence-context [p]
   {:data (when-let [refseqobj (sequence-fns/genomic-obj p)]
            (when-let [dna-sequence (sequence-fns/get-sequence refseqobj)]
              (let [strand (if-let [strand-kw (:locatable/strand p)]
@@ -36,4 +36,4 @@
   {:name generic/name-field
    :predicted_exon_structure generic/predicted-exon-structure
    :strand strand
-   :print_sequence print-sequence})
+   :sequence_context sequence-context})

--- a/src/rest_api/classes/sequence/core.clj
+++ b/src/rest_api/classes/sequence/core.clj
@@ -157,9 +157,9 @@
     ((comp vec flatten conj) features
      [{:type :padding
        :start 1
-       :stop (- padding 1)}
+       :stop  padding}
       {:type :padding
-       :start (+ 2 (- length padding))
+       :start (- length padding)
        :stop length}])))
 
 (defn transcript-sequence-features [transcript padding status]

--- a/src/rest_api/classes/sequence/core.clj
+++ b/src/rest_api/classes/sequence/core.clj
@@ -36,7 +36,8 @@
         (sequence-features sequence-database (id-kw object) role)))))
 
 (defn get-transcript-segments [object feature-id]
-  (let [g-species (get-g-species object "transcript")
+  (let [g-species (or (get-g-species object "transcript")
+                      (get-g-species object "cds"))
         sequence-database (seqdb/get-default-sequence-database g-species)]
     (when sequence-database
       (when-let [db ((keyword sequence-database) wb-seq/sequence-dbs)]
@@ -86,7 +87,8 @@
 (defn genomic-obj [object]
   (let [id-kw (first (filter #(= (name %) "id") (keys object)))
         role (namespace id-kw)]
-  (when-let [segment (if (= "transcript" role)
+  (when-let [segment (if (or (= "cds" role)
+                             (= "transcript" role))
                        (get-transcript-segment object)
                        (get-longest-segment object))]
     (let [[start stop] (->> segment
@@ -153,6 +155,32 @@
            :stop new-stop-position
            :type (:type feature)}))))
 
+(defn- add-introns [features]
+  (let [features-with-introns (atom ())
+        intron-and-exon-features (filter #(or (= "exon" (:type %))
+                                              (= "intron" (:type %))) features)
+        non-intron-and-exon-features (filter #(and (not= "exon" (:type %))
+                                                   (not= "intron" (:type %))) features)]
+    (do
+      (doseq [feature (sort-by :start intron-and-exon-features)]
+        (if (or (= (count @features-with-introns) 0)
+                (= (:stop (last @features-with-introns))
+                   (- (:start feature) 1)))
+          (swap! features-with-introns conj feature)
+          (do
+            (swap! features-with-introns conj (let [stop (- (:start feature) 1)]
+                                                {:start (+ (:stop (last
+                                                                    (filter
+                                                                      #(< (:stop %) stop)
+                                                                      (sort-by :start @features-with-introns))))
+                                                           1)
+                                               :stop stop
+                                               :type "intron"}))
+            (swap! features-with-introns conj feature))))
+      (doseq [feature (sort-by :start non-intron-and-exon-features)]
+        (swap! features-with-introns conj feature))
+      @features-with-introns)))
+
 (defn- add-padding-to-feature-list [features padding length]
   (when (> padding 0)
     ((comp vec flatten conj) features
@@ -165,124 +193,128 @@
 
 (defn transcript-sequence-features [transcript padding status]
   (when-let [refseq-obj (genomic-obj transcript)]
-    (let [seq-features (genomic-obj-child-positions transcript (:feature_id refseq-obj))]
-        (let [status-parts  (case status
-                              :spliced
-                              #{:exon :three_prime_UTR :five_prime_UTR}
+    (let [seq-features (genomic-obj-child-positions transcript (:feature_id refseq-obj))
+          status-parts  (case status
+                          :spliced
+                          #{:exon :three_prime_UTR :five_prime_UTR}
 
-                              :cds
-                              #{:exon}
+                          :cds
+                          #{:exon}
 
-                              #{:intron :exon :three_prime_UTR :five_prime_UTR})
-              three-prime-utr (first (filter (comp #{"three_prime_UTR"} :type) seq-features))
-              five-prime-utr (first (filter (comp #{"five_prime_UTR"} :type) seq-features))
-              cds (first (filter (comp #{"CDS"} :type) seq-features))
-              sequence-strand (if (some nil? [three-prime-utr  five-prime-utr])
-                                (when-let [strand (:locatable/strand transcript)]
-                                  (cond
-                                    (= strand :locatable.strand/negative) "-"
-                                    (= strand :locatable.strand/positive) "+"))
-                                (if (< (:start five-prime-utr) (:stop three-prime-utr)) "+" "-"))
-              context-obj (if (and (= status :cds) (some? cds))cds refseq-obj)
-              [context-left context-right] (if (neg? (- (:start context-obj) (:stop context-obj)))
-                                             [(- (:start context-obj) padding) (+ (:stop context-obj) padding)]
-                                             [(- (:stop context-obj) padding) (+ (:start context-obj) padding)])
-              positive-features (some->> seq-features
-                                         (map (fn [feature]
-                                                (let [feature-type (keyword (:type feature))
-                                                      [left-position right-position]
-                                                      (if (neg? (- (:start feature) (:stop feature)))
-                                                        [(:start feature) (:stop feature)]
-                                                        [(:stop feature) (:start feature)])]
-                                                  (when (and (not= feature-type :CDS)
-                                                             (not
-                                                               (and (= status :cds)
-                                                                    (or (= feature-type :five_prime_UTR)
-                                                                        (= feature-type :three_prime_UTR)))))
-                                                    {:start (let [start (+ 1 (- left-position context-left))]
-                                                              (if (neg? start) 1 start))
-                                                     :stop (let [stop (+ 1 (- right-position context-left))]
-                                                             (let [length (+ 1 (- context-right context-left))]
-                                                               (if (> stop length) length stop)))
-                                                     :type feature-type}))))
-                                         (remove nil?))
-              sequence-positive-raw (get-sequence
-                                      (conj
-                                        refseq-obj
-                                        {:start context-left
-                                         :stop context-right}))
-              sequence-positive (let [dna-sequence (atom {:seq sequence-positive-raw})]
-                                  (do
-                                    (doseq [feature positive-features
-                                            :when (= :exon (:type feature))]
-                                      (swap! dna-sequence
-                                             assoc
-                                             :seq
-                                             (replace-in-str
-                                               "uppercase"
-                                               (:seq @dna-sequence)
-                                               (- (:start feature) 1)
-                                               (+ 1
-                                                  (- (:stop feature)
-                                                     (:start feature))))))
-                                    (doseq [feature positive-features
-                                            :when (or (= :three_prime_UTR (:type feature))
-                                                      (= :five_prime_UTR (:type feature)))]
-                                      (swap! dna-sequence
-                                             assoc
-                                             :seq
-                                             (replace-in-str
-                                               "lowercase"
-                                               (:seq @dna-sequence)
-                                               (- (:start feature) 1)
-                                               (+ 1
-                                                  (- (:stop feature)
-                                                     (:start feature))))))
-                                    (if (contains? #{:cds :spliced} status)
-                                      (doseq [feature (reverse (sort-by :start positive-features))
-                                              :when (not (some #(= (:type feature) %) status-parts))]
-                                        (swap! dna-sequence
-                                               assoc
-                                               :seq
-                                               (replace-in-str
-                                                 "remove"
-                                                 (:seq @dna-sequence)
-                                                 (- (:start feature) 1)
-                                                 (+ 1
-                                                    (- (:stop feature)
-                                                       (:start feature)))))))
-                                    (:seq @dna-sequence)))
-              modified-positive-features (case status
-                                           :unspliced
-                                           positive-features
+                          #{:intron :exon :three_prime_UTR :five_prime_UTR})
+          three-prime-utr (first (filter (comp #{"three_prime_UTR"} :type) seq-features))
+          five-prime-utr (first (filter (comp #{"five_prime_UTR"} :type) seq-features))
+          cds (first (filter (comp #{"CDS"} :type) seq-features))
+          mrna (first (filter (comp #{"mRNA"} :type) seq-features))
+          sequence-strand (if (some nil? [three-prime-utr  five-prime-utr])
+                            (when-let [strand (:locatable/strand transcript)]
+                              (cond
+                                (= strand :locatable.strand/negative) "-"
+                                (= strand :locatable.strand/positive) "+"))
+                            (if (< (:start five-prime-utr) (:stop three-prime-utr)) "+" "-"))
+          context-obj (if (and (= status :cds) (some? cds)) cds refseq-obj)
+          [context-left context-right] (if (neg? (- (:start context-obj) (:stop context-obj)))
+                                         [(- (:start context-obj) padding) (+ (:stop context-obj) padding)]
+                                         [(- (:stop context-obj) padding) (+ (:start context-obj) padding)])
 
-                                           :cds
-                                           (get-spliced-exon-positions positive-features)
+          seq-features-with-introns (add-introns seq-features)
+          positive-features (some->> seq-features-with-introns
+                                     (map (fn [feature]
+                                            (let [feature-type (keyword (:type feature))
+                                                  [left-position right-position]
+                                                  (if (neg? (- (:start feature) (:stop feature)))
+                                                    [(:start feature) (:stop feature)]
+                                                    [(:stop feature) (:start feature)])]
+                                              (when (and (not= feature-type :CDS)
+                                                         (and (not= feature-type :mRNA)
+                                                              (not
+                                                                (and (= status :cds)
+                                                                     (or (= feature-type :five_prime_UTR)
+                                                                         (= feature-type :three_prime_UTR))))))
+                                                {:start (let [start (+ 1 (- left-position context-left))]
+                                                          (if (neg? start) 1 start))
+                                                 :stop (let [stop (+ 1 (- right-position context-left))]
+                                                         (let [length (+ 1 (- context-right context-left))]
+                                                           (if (> stop length) length stop)))
+                                                 :type feature-type}))))
+                                     (remove nil?))
+          sequence-positive-raw (get-sequence
+                                  (conj
+                                    refseq-obj
+                                    {:start context-left
+                                     :stop context-right}))
+          sequence-positive (let [dna-sequence (atom {:seq sequence-positive-raw})]
+                              (do
+                                (doseq [feature positive-features
+                                        :when (= :exon (:type feature))]
+                                  (swap! dna-sequence
+                                         assoc
+                                         :seq
+                                         (replace-in-str
+                                           "uppercase"
+                                           (:seq @dna-sequence)
+                                           (- (:start feature) 1)
+                                           (+ 1
+                                              (- (:stop feature)
+                                                 (:start feature))))))
+                                (doseq [feature positive-features
+                                        :when (or (= :three_prime_UTR (:type feature))
+                                                  (= :five_prime_UTR (:type feature)))]
+                                  (swap! dna-sequence
+                                         assoc
+                                         :seq
+                                         (replace-in-str
+                                           "lowercase"
+                                           (:seq @dna-sequence)
+                                           (- (:start feature) 1)
+                                           (+ 1
+                                              (- (:stop feature)
+                                                 (:start feature))))))
+                                (if (contains? #{:cds :spliced} status)
+                                  (doseq [feature (reverse (sort-by :start positive-features))
+                                          :when (not (some #(= (:type feature) %) status-parts))]
+                                    (swap! dna-sequence
+                                           assoc
+                                           :seq
+                                           (replace-in-str
+                                             "remove"
+                                             (:seq @dna-sequence)
+                                             (- (:start feature) 1)
+                                             (+ 1
+                                                (- (:stop feature)
+                                                   (:start feature))))))))
+                              (:seq @dna-sequence))
+          modified-positive-features (case status
+                                       :unspliced
+                                       positive-features
 
-                                           :spliced
-                                           (remove nil?
-                                                   (flatten
-                                                     (conj
-                                                       (get-spliced-exon-positions positive-features)
-                                                       (if (= sequence-strand "+")
-                                                         (first (filter #(= (:type %) :five_primeUTR) positive-features))
-                                                         (first (filter #(= (:type %) :three_prime_UTR) positive-features)))
-                                                       (let [feature (if (= sequence-strand "+")
-                                                                       (first (filter #(= (:type %) :three_prime_UTR) positive-features))
-                                                                       (first (filter #(= (:type %) :five_prime_UTR) positive-features)))
-                                                             end (count sequence-positive)]
-                                                         (if (some? feature)
-                                                           (conj
-                                                             feature
-                                                             {:start (- end
-                                                                        (+ 1 (- (:stop feature) (:start feature))))
-                                                              :stop (count sequence-positive)})))))))
-              modified-positive-features-with-padding (if (> padding 0)
-                                                        (add-padding-to-feature-list
-                                                          modified-positive-features
-                                                          padding
-                                                          (count sequence-positive))
-                                                        modified-positive-features)]
+                                       :cds
+                                       (get-spliced-exon-positions positive-features)
+
+                                       :spliced
+                                       (remove nil?
+                                               (flatten
+                                                 (conj
+                                                   (get-spliced-exon-positions positive-features)
+                                                   (if (= sequence-strand "+")
+                                                     (first (filter #(= (:type %) :five_primeUTR) positive-features))
+                                                     (first (filter #(= (:type %) :three_prime_UTR) positive-features)))
+                                                   (let [feature (if (= sequence-strand "+")
+                                                                   (first (filter #(= (:type %) :three_prime_UTR) positive-features))
+                                                                   (first (filter #(= (:type %) :five_prime_UTR) positive-features)))
+                                                         end (count sequence-positive)]
+                                                     (if (some? feature)
+                                                       (conj
+                                                         feature
+                                                         {:start (- end
+                                                                    (+ 1 (- (:stop feature) (:start feature))))
+                                                          :stop (count sequence-positive)})))))))
+          modified-positive-features-with-padding (if (> padding 0)
+                                                    (add-padding-to-feature-list
+                                                      modified-positive-features
+                                                      padding
+                                                      (count sequence-positive))
+                                                    modified-positive-features)]
                    {:positive_strand
                     {:features modified-positive-features-with-padding
                     :sequence sequence-positive}
@@ -297,4 +329,4 @@
                                               (feature-complement (:features @neg-features) feature seq-length)))
                                      (:features @neg-features))))
                      :sequence (generic-functions/dna-reverse-complement sequence-positive)}
-                    :strand sequence-strand}))))
+                    :strand sequence-strand})))

--- a/src/rest_api/classes/sequence/core.clj
+++ b/src/rest_api/classes/sequence/core.clj
@@ -162,7 +162,7 @@
        :start (+ 2 (- length padding))
        :stop length}])))
 
-(defn transcript-sequence-features [transcript padding status] ; status can be :cds, :spliced, and :unspliced
+(defn transcript-sequence-features [transcript padding status]
   (when-let [refseq-obj (genomic-obj transcript)]
     (let [seq-features (genomic-obj-child-positions transcript)
           padding (if (> padding 0) (- padding 1) 0)
@@ -271,12 +271,12 @@
                                                               (+ 1 (- (:stop feature) (:start feature))))
                                                     :stop (count sequence-positive)}))
                                                )))]
-      {:positive-strand
+      {:positive_strand
        {:features (if (> padding 0)
                     (add-padding-to-feature-list modified-positive-features padding (count sequence-positive))
                     modified-positive-features)
         :sequence sequence-positive}
-       :negative-strand
+       :negative_strand
        {:features (when-let [seq-length (count sequence-positive)]
                     (let [neg-features (atom {:features ()})]
                       (do
@@ -287,4 +287,4 @@
                                  (feature-complement (:features @neg-features) feature seq-length)))
                         (:features @neg-features))))
         :sequence (generic-functions/dna-reverse-complement sequence-positive)}
-       :sequence_strand sequence-strand})))
+       :strand sequence-strand})))

--- a/src/rest_api/classes/sequence/core.clj
+++ b/src/rest_api/classes/sequence/core.clj
@@ -152,6 +152,16 @@
            :stop new-stop-position
            :type (:type feature)}))))
 
+(defn- add-padding-to-feature-list [features padding length]
+  (when (> padding 0)
+    ((comp vec flatten conj) features
+     [{:type :padding
+       :start 1
+       :stop (- padding 1)}
+      {:type :padding
+       :start (+ 2 (- length padding))
+       :stop length}])))
+
 (defn transcript-sequence-features [transcript padding status] ; status can be :cds, :spliced, and :unspliced
   (when-let [refseq-obj (genomic-obj transcript)]
     (let [seq-features (genomic-obj-child-positions transcript)
@@ -261,7 +271,9 @@
                                                     :stop (count sequence-positive)}))
                                                )))]
       {:positive-strand
-       {:features modified-positive-features
+       {:features (if (> padding 0)
+                    (add-padding-to-feature-list modified-positive-features padding (count sequence-positive))
+                    modified-positive-features)
         :sequence sequence-positive}
        :negative-strand
        {:features (when-let [seq-length (count sequence-positive)]

--- a/src/rest_api/classes/sequence/core.clj
+++ b/src/rest_api/classes/sequence/core.clj
@@ -165,6 +165,7 @@
 (defn transcript-sequence-features [transcript padding status] ; status can be :cds, :spliced, and :unspliced
   (when-let [refseq-obj (genomic-obj transcript)]
     (let [seq-features (genomic-obj-child-positions transcript)
+          padding (if (> padding 0) (- padding 1) 0)
           status-parts  (case status
                           :spliced
                           #{:exon :three_prime_UTR :five_prime_UTR}

--- a/src/rest_api/classes/sequence/core.clj
+++ b/src/rest_api/classes/sequence/core.clj
@@ -16,15 +16,15 @@
 
 (defn get-g-species [object role]
   (when-let [species-name (:species/id
-                             (or
-                               ((keyword role "species") object)
-                               (or
-                                 (:clone/species
-                                   (first
-                                     (:pcr-product/clone object)))
-                                 (:transcript/species
-                                   (first
-                                     (:transcript/_corresponding-pcr-product object))))))]
+                            (or
+                              ((keyword role "species") object)
+                              (or
+                                (:clone/species
+                                  (first
+                                    (:pcr-product/clone object)))
+                                (:transcript/species
+                                  (first
+                                    (:transcript/_corresponding-pcr-product object))))))]
     (generic-functions/xform-species-name species-name)))
 
 (defn get-segments [object]
@@ -55,19 +55,19 @@
   (let [id-kw (first (filter #(= (name %) "id") (keys object)))
         role (namespace id-kw)
         calc-browser-pos (fn [x-op x y mult-offset]
-                            (if gbrowse
-                              (->> (reduce - (sort-by - [x y]))
-                                   (double)
-                                   (* mult-offset)
-                                   (int)
-                                   (x-op x))
-                              y))
+                           (if gbrowse
+                             (->> (reduce - (sort-by - [x y]))
+                                  (double)
+                                  (* mult-offset)
+                                  (int)
+                                  (x-op x))
+                             y))
         browser-start (calc-browser-pos - start stop 0.2)
         browser-stop (calc-browser-pos + stop start 0.5)
         id (str (:seqname segment) ":" browser-start ".." browser-stop)
         label (if (= img true)
-                   id
-                 (str (:seqname segment) ":" start ".." stop))]
+                id
+                (str (:seqname segment) ":" start ".." stop))]
     (pace-utils/vmap
       :class "genomic_location"
       :id id
@@ -82,15 +82,15 @@
 (defn genomic-obj [object]
   (when-let [segment (get-longest-segment object)]
     (let [[start stop] (->> segment
-                             ((juxt :start :end))
-                             (sort-by +))]
+                            ((juxt :start :end))
+                            (sort-by +))]
       (create-genomic-location-obj start stop object segment nil true true))))
 
 (defn genomic-obj-position [object]
   (when-let [segment (get-longest-segment object)]
     (let [[start stop] (->> segment
-                             ((juxt :start :end))
-                             (sort-by +))]
+                            ((juxt :start :end))
+                            (sort-by +))]
       (create-genomic-location-obj start stop object segment nil true false))))
 
 (defn genomic-obj-child-positions [object]
@@ -138,76 +138,49 @@
      :stop feature-end
      :type (:type feature)}))
 
-(defn transcript-sequence-features [transcript padding status] ; status can be spliced, spliced-with-utr, and unspliced
+(defn transcript-sequence-features [transcript padding status] ; status can be :cds, :spliced, and :unspliced
   (when-let [refseq-obj (genomic-obj transcript)]
-    (let [
-          dddd (println refseq-obj)
-          seq-features (genomic-obj-child-positions transcript)
-          ddddd (println seq-features)
+    (let [seq-features (genomic-obj-child-positions transcript)
+          status :spliced
           three-prime-utr (first (filter (comp #{"three_prime_UTR"} :type) seq-features))
           five-prime-utr (first (filter (comp #{"five_prime_UTR"} :type) seq-features))
-          sequence-strand (if (> (:start three-prime-utr) (:start five-prime-utr)) "+" "-")
-          start (if (= "+" sequence-strand)
-                  (if (= status "spliced")
-                    (+ 1 (:stop five-prime-utr))
-                    (:start five-prime-utr))
-                  (if (= status "spliced")
-                    (- (:start three-prime-utr) 1)
-                    (:stop three-prime-utr)))
-          stop (if (= "+" sequence-strand)
-                  (if (= status "spliced")
-                    (- (:start three-prime-utr) 1)
-                    (:stop three-prime-utr))
-                  (if (= status "spliced")
-                    (+ (:stop five-prime-utr) 1)
-                    (:start three-prime-utr)))
-          features-raw (when-let [features seq-features]
-                         (some->> features
-                                  (map (fn [feature]
-                                         (when (not= "CDS" (:type feature))
-                                           {:start (+ 1
-                                                      (+ padding
-                                                         (if (= sequence-strand "+")
-                                                           (- (if (= status "spliced-with-utr" (if-let [five-prime-utr-start (:start five-prime-utr)]
-                                                                five-prime-utr-start
-                                                                (:start feature))
-                                                              (:start refseq-obj))
-                                                           (- (:stop feature)
-                                                             (if-let [three-prime-utr-start (:start three-prime-utr)]
-                                                                three-prime-utr-start
-                                                                (:stop refseq-obj))))))
-                                            :stop (+ 1
-                                                     (+ padding
-                                                       (if (= sequence-strand "+")
-                                                          (- (:stop feature)
-                                                             (if-let [three-prime-utr-start (:start three-prime-utr)]
-                                                               three-prime-utr-start
-                                                               (:start refseq-obj)))
-                                                          (- (:start feature)
-                                                             (if-let [three-prime-utr-start (:start three-prime-utr)]
-                                                               three-prime-utr-start
-                                                               (:stop refseq-obj))))))
-                                            :type (:type feature)})))
-                                  (remove nil?)))
+          cds (first (filter (comp #{"CDS"} :type) seq-features))
+          sequence-strand (if (< (:start five-prime-utr) (:stop three-prime-utr)) "+" "-")
+          context-obj (if (= status :cds) cds refseq-obj)
+          [context-left context-right] (if (neg? (- (:start context-obj) (:stop context-obj)))
+                                         [(:start context-obj) (:stop context-obj)]
+                                         [(:stop context-obj) (:start context-obj)])
+          positive-features (some->> seq-features
+                                     (map (fn [feature]
+                                            (let [feature-type (keyword (:type feature))
+                                                  [left-position right-position]
+                                                  (if (< (:start feature) (:stop feature))
+                                                    [(:start feature) (:stop feature)]
+                                                    [(:stop feature) (:start feature)])]
+                                              (when (and (not= feature-type :CDS)
+                                                         (not
+                                                           (and (= status :cds)
+                                                                (or (= feature-type :five_prime_UTR)
+                                                                    (= feature-type :three_prime_UTR)))))
+                                                {:start (let [start (+ 1
+                                                                       (+ padding
+                                                                          (- left-position context-left)))]
+                                                          (if (neg? start) 0 start))
+                                                 :stop (let [stop (+ 1
+                                                                     (+ padding
+                                                                        (- right-position context-left)))]
+                                                         (let [length (+ 1 (- context-right context-left))]
+                                                           (if (> stop length) length stop)))
+                                                 :type feature-type}))))
+                                     (remove nil?))
           sequence-positive-raw (get-sequence
                                   (conj
                                     refseq-obj
-                                    (if (= sequence-strand "+")
-                                      {:start (if-let [three-prime-utr-start (:start three-prime-utr)]
-                                                (- three-prime-utr-start padding)
-                                                (- (:start refseq-obj) padding))
-                                       :stop (if-let [five-prime-utr-stop (:stop five-prime-utr)]
-                                               (+ five-prime-utr-stop padding)
-                                               (+ (:stop refseq-obj) padding))}
-                                      {:start (if-let [five-prime-utr-start (:start five-prime-utr)]
-                                                (- five-prime-utr-start padding)
-                                                (- (:stop refseq-obj) padding))
-                                       :stop  (if-let [three-prime-utr-start (:start three-prime-utr)]
-                                                (+ three-prime-utr-start padding)
-                                                (+ (:start refseq-obj) padding))})))
+                                    {:start context-left
+                                     :stop context-right}))
           sequence-positive (let [dna-sequence (atom {:seq sequence-positive-raw})]
                               (do
-                                (doseq [feature features-raw
+                                (doseq [feature positive-features
                                         :when (= "exon" (:type feature))]
                                   (swap! dna-sequence
                                          assoc
@@ -219,7 +192,7 @@
                                            (+ 1
                                               (- (:stop feature)
                                                  (:start feature))))))
-                                (doseq [feature features-raw
+                                (doseq [feature positive-features
                                         :when (or (= "three_prime_UTR" (:type feature))
                                                   (= "five_prime_UTR" (:type feature)))]
                                   (swap! dna-sequence
@@ -232,8 +205,8 @@
                                            (+ 1
                                               (- (:stop feature)
                                                  (:start feature))))))
-                                (if (= status "spliced-with-utr")
-                                  (doseq [feature (reverse (sort-by :start features-raw))
+                                (if (= status :cds)
+                                  (doseq [feature (reverse (sort-by :start positive-features))
                                           :when (contains? (set `("intron" "three_prime_UTR" "five_prime_UTR")) (:type feature))]
                                     (swap! dna-sequence
                                            assoc
@@ -245,8 +218,8 @@
                                              (+ 1
                                                 (- (:stop feature)
                                                    (:start feature)))))))
-                                (if (= status "spliced")
-                                  (doseq [feature (reverse (sort-by :start features-raw))
+                                (if (= status :spliced)
+                                  (doseq [feature (reverse (sort-by :start positive-features))
                                           :when (= "intron" (:type feature))]
                                     (swap! dna-sequence
                                            assoc
@@ -259,25 +232,7 @@
                                                 (- (:stop feature)
                                                    (:start feature)))))))
 
-                                (:seq @dna-sequence)))
-
-          positive-features (if (= status "unspliced")
-                              features-raw
-                              (let [pos-features (atom {:features ()})
-                                    next-feature-start (atom 1)]
-                                (do
-                                  (doseq [feature (sort-by :start features-raw)
-                                          :when (and
-                                                  (not= "three_prime_UTR" (:type feature))
-                                                  (not= "five_prime_UTR" (:type feature))
-                                                  (not= "intron" (:type feature)))
-                                          :let [feature-end (+ (deref next-feature-start) (- (:stop feature) (:start feature)))]]
-                                    (swap! pos-features
-                                           assoc
-                                           :features
-                                           (add-feature (:features @pos-features) feature (deref next-feature-start) feature-end))
-                                    (reset! next-feature-start (+ 1 (+ (deref next-feature-start) (- (:stop feature) (:start feature))))))
-                                  (:features @pos-features))))]
+                                (:seq @dna-sequence)))]
       {:positive-strand
        {:features positive-features
         :sequence sequence-positive}

--- a/src/rest_api/classes/transcript.clj
+++ b/src/rest_api/classes/transcript.clj
@@ -42,7 +42,7 @@
     :external_links external-links/widget
     :location location/widget
     :feature feature/widget
-    ;:sequences sequences/widget
+    :sequences sequences/widget
     :references references/widget}
    :field
    {:fpkm_expression_summary_ls exp/fpkm-expression-summary-ls}})

--- a/src/rest_api/classes/transcript/widgets/sequences.clj
+++ b/src/rest_api/classes/transcript/widgets/sequences.clj
@@ -25,8 +25,10 @@
    :description "the spliced sequence of the sequence"})
 
 (defn protein-sequence [t]
-  {:data (when-let [peptide (some->> (:transcript/corresponding-protein t)
-                                     (:transcript.corresponding-protein/protein)
+  {:data (when-let [peptide (some->> (->> t :transcript/corresponding-cds
+                                            :transcript.corresponding-cds/cds
+                                            :cds/corresponding-protein)
+                                     (:cds.corresponding-protein/protein)
                                      (:protein/peptide)
                                      (:protein.peptide/peptide)
                                      (:peptide/sequence))]

--- a/src/rest_api/classes/transcript/widgets/sequences.clj
+++ b/src/rest_api/classes/transcript/widgets/sequences.clj
@@ -13,7 +13,7 @@
    :description "strand orientation of the sequence"})
 
 (defn unspliced-sequence-context-with-padding [t]
-  {:data (sequence-fns/transcript-sequence-features t 2001 :unspliced)
+  {:data (sequence-fns/transcript-sequence-features t 2000 :unspliced)
    :description "the unpliced sequence of the sequence"})
 
 (defn unspliced-sequence-context [t]

--- a/src/rest_api/classes/transcript/widgets/sequences.clj
+++ b/src/rest_api/classes/transcript/widgets/sequences.clj
@@ -21,7 +21,7 @@
    :description "the unpliced sequence of the sequence"})
 
 (defn spliced-sequence-context [t]
-  {:data (sequence-fns/transcript-sequence-features t 0 "spliced-plus-utr")
+  {:data (sequence-fns/transcript-sequence-features t 0 "spliced-with-utr")
    :description "the spliced sequence of the sequence"})
 
 (defn protein-sequence [t]

--- a/src/rest_api/classes/transcript/widgets/sequences.clj
+++ b/src/rest_api/classes/transcript/widgets/sequences.clj
@@ -13,15 +13,15 @@
    :description "strand orientation of the sequence"})
 
 (defn unspliced-sequence-context-with-padding [t]
-  {:data (sequence-fns/transcript-sequence-features t 2001 "unspliced")
+  {:data (sequence-fns/transcript-sequence-features t 2001 :unspliced)
    :description "the unpliced sequence of the sequence"})
 
 (defn unspliced-sequence-context [t]
-  {:data (sequence-fns/transcript-sequence-features t 0 "unspliced")
+  {:data (sequence-fns/transcript-sequence-features t 0 :unspliced)
    :description "the unpliced sequence of the sequence"})
 
 (defn spliced-sequence-context [t]
-  {:data (sequence-fns/transcript-sequence-features t 0 "spliced-with-utr")
+  {:data (sequence-fns/transcript-sequence-features t 0 :spliced)
    :description "the spliced sequence of the sequence"})
 
 (defn protein-sequence [t]

--- a/src/rest_api/db/sequence.clj
+++ b/src/rest_api/db/sequence.clj
@@ -61,10 +61,17 @@
         (sequencesql/get-features-by-id db-spec attribute)))))
 
 (defn sequence-features-where-type [db-spec feature-name method]
-  (sequencesql/sequence-features-where-type
-    db-spec
-    {:name feature-name
-     :tag method}))
+  (let [features (sequencesql/sequence-features-where-type
+                      db-spec
+                      {:name feature-name
+                       :tag method}) ]
+    (if (> (count features) 0)
+      features
+      (when (= method "CDS%")
+        (sequencesql/sequence-features-where-type
+          db-spec
+          {:name feature-name
+           :tag "mRNA%"})))))
 
 (defn variation-features [db-spec variation-name]
   (sequencesql/variation-features

--- a/src/rest_api/db/sequence.clj
+++ b/src/rest_api/db/sequence.clj
@@ -95,5 +95,4 @@
           (- high low-offset))))
 
 (defn get-seq-features [db-spec transcript]
-  (do (println "DDDD") (println transcript) (println "EEEE")
-  (sequencesql/get-seq-features db-spec {:name transcript})))
+  (sequencesql/get-seq-features db-spec {:name transcript}))

--- a/src/rest_api/db/sql/sequence.sql
+++ b/src/rest_api/db/sql/sequence.sql
@@ -65,14 +65,14 @@ AND s.offset = :offset
 
 -- :name get-seq-features :? :*
 -- :doc Retreive all sequence features from transcript
-SELECT tc.tag,fc.start AS start,fc.end AS stop
+SELECT t.tag,fc.start AS start,fc.end AS stop
 FROM feature as f
 LEFT OUTER JOIN parent2child as pc ON pc.id=f.id
-LEFT OUTER JOIN typelist as t ON t.id=f.typeid
 LEFT OUTER JOIN feature as fc ON pc.child=fc.id
-LEFT OUTER JOIN typelist as tc ON tc.id=fc.typeid
+LEFT OUTER JOIN typelist as t ON t.id=fc.typeid
 LEFT OUTER JOIN name as n ON n.id=f.id
 WHERE n.name = :name
 AND (t.tag LIKE "transcript%"
 	    OR t.tag LIKE "CDS%"
+	    OR t.tag LIKE "exon%"
 	    OR t.tag LIKE "mRNA%")


### PR DESCRIPTION
This makes it so that the sequence widgets for CDS, Transcript, and Pseudogene. I believe it is ready for curator testing on staging. 

**This has been tested with cases pointed out by Paul Davis**
miRNA - http://sibyl.wormbase.org/species/c_elegans/transcript/AC8.8#67--10

tRNA - http://sibyl.wormbase.org/species/c_elegans/transcript/C10G8.t1#67--10

piRNA - http://sibyl.wormbase.org/species/c_elegans/transcript/AC7.16#67--10

lincRNA - http://sibyl.wormbase.org/species/c_elegans/transcript/AH9.8#67--10

asRNA - http://sibyl.wormbase.org/species/c_elegans/transcript/B0019.4#67--10

snoRNA - http://sibyl.wormbase.org/species/c_elegans/transcript/B0041.9#67--10

snRNA - http://sibyl.wormbase.org/species/c_elegans/transcript/B0205.15#67--10

rRNA - http://sibyl.wormbase.org/species/c_elegans/transcript/F31C3.7#67--10

scRNA - http://sibyl.wormbase.org/species/c_elegans/transcript/F55G1.16#67--10
7kncRNA - http://sibyl.wormbase.org/species/c_elegans/transcript/B0034.14#67--10
ncRNA - http://sibyl.wormbase.org/species/c_elegans/transcript/C14A11.13#67--10

I could only find some Coding_transcripts that actually work and even then, some don't:

Fail - http://sibyl.wormbase.org/species/c_elegans/transcript/2L52.1a.1#67--10

Works - http://sibyl.wormbase.org/species/c_elegans/transcript/K08E3.6.1#67--10-6
Fail - http://sibyl.wormbase.org/species/c_elegans/transcript/C41G7.7.1#67--10-6

Besides non-coding RNA, do you know of any other trickier or edge case that we need to watch out for? Those would be very helpful too.
Not that I can think of off the top of my head.

Maybe Transposon in origin genes:

CDS - http://sibyl.wormbase.org/species/c_elegans/cds/C17H11.3#67--10

Transcript - http://sibyl.wormbase.org/species/c_elegans/transcript/H05L03.6#67--10

