### PR TITLE
hotfix gene_class previous_genes widget 

### DIFF
--- a/src/rest_api/classes/gene_class/widgets/previous_genes.clj
+++ b/src/rest_api/classes/gene_class/widgets/previous_genes.clj
@@ -51,7 +51,10 @@
                                 public-name (:gene/public-name gene)]
                             (some->> (:gene/other-name gene)
                                      (map :gene.other-name/text)
-                                     (filter #(.contains % public-name))
+                                     (filter (fn [other-name]
+                                               (and
+                                                (identity public-name)
+                                                (.contains other-name public-name))))
                                      (map #(stash-former-member % gene))))))
                       (flatten)
                       (group-by :species-name))))


### PR DESCRIPTION
@adamjohnwright pre-caching script saw failures due to :gene/public-name being null.
Could you doublecheck my fix doesn't break any of your intended behaviour? Thanks!

Also this seems to be a new failure. I have run the same pre-caching scripts in the previous release without these issues. I wonder if there is some underlying data difference that is worth looking into.

examples:

/rest/widget/gene_class/cpb/previous_genes
/rest/widget/gene_class/tig/previous_genes
/rest/widget/gene_class/plc/previous_genes
