### PR TITLE
Feature/280 VEP round 2

### DIFF
--- a/src/rest_api/classes/variation/widgets/molecular_details.clj
+++ b/src/rest_api/classes/variation/widgets/molecular_details.clj
@@ -673,8 +673,7 @@
              (some->> (:variation/transcript variation)
                       (map (fn [h]
                              (let [t (:variation.transcript/transcript h)]
-                               (when-let [refseqobj (sequence-fns/genomic-obj t)]
-                                 (conj
+                               (conj
                                    (pack-obj t)
                                    (when (some? varrefseqobj)
                                      (fetch-coords-in-feature varrefseqobj t))
@@ -762,7 +761,7 @@
 
                                         :UTR_3
                                         (get-feature-affected-evidence
-                                          (:molecular-change/three-prime-utr h))))}))))))
+                                          (:molecular-change/three-prime-utr h))))})))))
 
              "Pseudogene" ;tested with WBVar00601206
              (some->> (:variation/pseudogene variation)

--- a/src/rest_api/classes/variation/widgets/molecular_details.clj
+++ b/src/rest_api/classes/variation/widgets/molecular_details.clj
@@ -706,6 +706,12 @@
                                                                (str/replace "_" " "))
                                                  :evidence {:SIFT_score (:molecular-change.sift/float sift)}})))
 
+                                    :cds
+                                    (some->> (:variation.transcript/transcript h)
+                                             (:transcript/corresponding-cds)
+                                             (:transcript.corresponding-cds/cds)
+                                             (pack-obj))
+
                                     :cds_position
                                     (some->> (:molecular-change/cds-position h)
                                              (first)


### PR DESCRIPTION
WormBase/website#8151
- remove the unused assignment `refseqobj` that mistakenly filtered out the pseudogenes.
- Include CDS that corresponds to the transcript