### PR TITLE
lining up predicted cds with cds and amino acid 

### DIFF
--- a/src/rest_api/classes/variation/core.clj
+++ b/src/rest_api/classes/variation/core.clj
@@ -62,8 +62,10 @@
                          & {:keys [window]
                             :or {window 20}}]
   (let [slice (comp seq (partial take window))
-        cds-changes (->> (:variation/predicted-cds var)
-                         (filter #(relevant-location? (:variation.predicted-cds/cds %)))
+        cds-changes (->> (:variation/transcript var)
+                         (:variation.transcript/transcript)
+                         (:transcript/corresponding-cds)
+                         (filter #(relevant-location? (:transcript.corresponding-cds/cds %)))
                          (slice))
         trans-changes (->> (:variation/transcript var)
                            (filter #(relevant-location? (:variation.transcript/transcript %)))
@@ -153,7 +155,7 @@
      (->> (for [cc cds-changes
                 :when (or (:molecular-change/missense cc)
                           (:molecular-change/nonsense cc))]
-            (pack-obj "cds" (:variation.predicted-cds/cds cc)))
+            (pack-obj "cds" (:variation.transcript/cds cc)))
           (seq)
           (not-empty))
      :phen_count


### PR DESCRIPTION
This change affects all pages where we have the protein sequence for the variation here is the main one that I found: https://staging.wormbase.org/species/c_elegans/variation/WBVar00466445#69--10

Fortunately, most of the logic is the exact same as before for generated the AA sequences. 